### PR TITLE
isEditable logic was actually returning !isEditable, reversed return …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,11 +283,11 @@ class MarkdownEditor extends React.Component {
       if (editor.value.activeMarks.size > 0 && editor.value.activeMarks.every(
         (mark => mark.type === 'variable'),
       )) {
-        return true;
+        return false;
       }
     }
 
-    return false;
+    return true;
   }
 
   onBeforeInput(event, editor, next) {


### PR DESCRIPTION
It appears the logic was accidentally reversed.   If you look at the example, you can only edit variables, everything else is locked.