### PR TITLE
feat(SlateAsInputEditor): update slate value when props change so Editor re-renders

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -147,6 +147,13 @@ function SlateAsInputEditor(props) {
   }, [onChange, plugins, slateValue]);
 
   /**
+   * - Updates the Slate value on state when props.value changes
+   */
+  useEffect(() => {
+    setSlateValue(props.value ? Value.fromJSON(props.value) : defaultValue);
+  }, [props.value]);
+
+  /**
    * - Set a lockText annotation on the editor equal to props.lockText
    */
   useEffect(() => {
@@ -516,26 +523,25 @@ function SlateAsInputEditor(props) {
   const card = <Card fluid>
   <Card.Content>
   <EditorWrapper>
-              <
-// @ts-ignore
-              Editor
-              ref={editorRef}
-              className="doc-inner"
-              value={slateValue}
-              readOnly={props.readOnly}
-              onChange={({ value }) => {
-                setSlateValue(value);
-              }}
-              schema={slateSchema}
-              plugins={props.plugins}
-              onBeforeInput={onBeforeInput}
-              onKeyDown={onKeyDown}
-              onPaste={onPaste}
-              renderBlock={renderBlock}
-              renderInline={renderInline}
-              renderMark={renderMark}
-              renderAnnotation={renderAnnotation}
-              renderEditor={renderEditor}/>
+    <Editor
+      ref={editorRef}
+      className="doc-inner"
+      value={slateValue}
+      readOnly={props.readOnly}
+      onChange={({ value }) => {
+        setSlateValue(value);
+      }}
+      schema={slateSchema}
+      plugins={props.plugins}
+      onBeforeInput={onBeforeInput}
+      onKeyDown={onKeyDown}
+      onPaste={onPaste}
+      renderBlock={renderBlock}
+      renderInline={renderInline}
+      renderMark={renderMark}
+      renderAnnotation={renderAnnotation}
+      renderEditor={renderEditor}
+    />
     </EditorWrapper>
   </Card.Content>
 </Card>;

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -94,7 +94,10 @@ function SlateAsInputEditor(props) {
    * Current Slate Value, initialized by converting props.markdown
    * to a Slate Value
    */
-  const [slateValue, setSlateValue] = useState(props.value || Value.fromJSON(defaultValue));
+  const [
+    slateValue,
+    setSlateValue
+  ] = useState(props.value ? Value.fromJSON(props.value) : defaultValue);
 
   /**
    * Slate Schema augmented by plugins


### PR DESCRIPTION
With this change, the demo example works so that if the markdown editor on the left is changed, the rich text editor on the right will re-render with the updated content.