### PR TITLE
fix(FormatToolbar): correct responsive design for static toolbar - I48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5922,8 +5922,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5947,15 +5946,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5972,22 +5969,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6118,8 +6112,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6133,7 +6126,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6150,7 +6142,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6159,15 +6150,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6188,7 +6177,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6277,8 +6265,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6292,7 +6279,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6388,8 +6374,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6431,7 +6416,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6453,7 +6437,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6502,15 +6485,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/FormatToolbar.js
+++ b/src/FormatToolbar.js
@@ -17,6 +17,8 @@ import * as lIcon from './icons/hyperlink';
 import * as unIcon from './icons/navigation-left';
 import * as reIcon from './icons/navigation-right';
 
+import './toolbar.css';
+
 const whiteColor = '#FFFFFF';
 const lightGrey = '#F0F0F0';
 const mediumGrey = '#949CA2';
@@ -27,15 +29,7 @@ const DEFAULT_NODE = 'paragraph';
 
 const StyledToolbar = styled.div`
   position: relative;
-  display: grid
-  grid-column-start: 1;
-  grid-row-start: 1;
   justify-self: end;
-  grid-template-columns:
-    auto auto auto auto
-    auto auto auto auto
-    auto auto auto auto
-    auto auto auto auto;
   width: 450px;
   background-color: #FFFFFF !important;
 `;
@@ -61,6 +55,21 @@ const VertDivider = styled.div`
   border: 1px solid #EFEFEF;
   top: 10px;
   place-self: center;
+  @media (max-width: 1050px) {
+    display: none;
+  }
+`;
+
+const VertDividerResponsive = styled.div`
+  box-sizing: border-box;
+  height: 24px;
+  width: 1px;
+  border: 1px solid #EFEFEF;
+  top: 10px;
+  place-self: center;
+  @media (max-width: 1340px) {
+    display: none;
+  }
 `;
 
 export default class FormatToolbar extends React.Component {
@@ -134,7 +143,7 @@ export default class FormatToolbar extends React.Component {
   /**
    * Render a mark-toggling toolbar button.
    */
-  renderMarkButton(type, icon, hi, wi, pa, vBox) {
+  renderMarkButton(type, icon, hi, wi, pa, vBox, classInput) {
     const { editor } = this.props;
     const isActive = action.hasMark(editor, type);
     const fillActivity = isActive ? darkGrey : mediumGrey;
@@ -148,6 +157,7 @@ export default class FormatToolbar extends React.Component {
         width={wi}
         height={hi}
         padding={pa}
+        className={classInput}
         onPointerDown={event => this.onClickMark(event, type)}>
           {icon(fillActivity)}
       </ ToolbarIcon>
@@ -157,7 +167,7 @@ export default class FormatToolbar extends React.Component {
   /**
    * Render a block modifying button
    */
-  renderBlockButton(type, icon, hi, wi, pa, vBox, props) {
+  renderBlockButton(type, icon, hi, wi, pa, vBox, classInput, props) {
     const { editor } = this.props;
     const isActive = action.hasBlock(editor, type);
     const fillActivity = isActive ? darkGrey : mediumGrey;
@@ -171,6 +181,7 @@ export default class FormatToolbar extends React.Component {
         width={wi}
         height={hi}
         padding={pa}
+        className={classInput}
         {...props}
         onPointerDown={event => this.onClickBlock(event, type, props)}>
           {icon(fillActivity)}
@@ -181,7 +192,7 @@ export default class FormatToolbar extends React.Component {
   /**
    * Render a link-toggling toolbar button.
    */
-  renderLinkButton(type, icon, hi, wi, pa, vBox) {
+  renderLinkButton(type, icon, hi, wi, pa, vBox, classInput) {
     const { editor } = this.props;
     const isActive = action.hasLinks(editor);
     const fillActivity = isActive ? linkColor : mediumGrey;
@@ -195,6 +206,7 @@ export default class FormatToolbar extends React.Component {
         height={hi}
         padding={pa}
         viewBox={vBox}
+        className={classInput}
         onPointerDown={event => action.onClickLink(event, this.props.editor)}>
           {icon(fillActivity)}
       </ ToolbarIcon>
@@ -204,7 +216,7 @@ export default class FormatToolbar extends React.Component {
   /**
    * Render a history-toggling toolbar button.
    */
-  renderHistoryButton(type, icon, hi, wi, pa, vBox, action) {
+  renderHistoryButton(type, icon, hi, wi, pa, vBox, action, classInput) {
     return (
       <ToolbarIcon
         aria-label={type}
@@ -213,6 +225,7 @@ export default class FormatToolbar extends React.Component {
         height={hi}
         padding={pa}
         viewBox={vBox}
+        className={classInput}
         onPointerDown={event => this.onClickHistory(event, action, this.props.editor)}>
           {icon(mediumGrey)}
       </ ToolbarIcon>
@@ -233,7 +246,8 @@ export default class FormatToolbar extends React.Component {
             bIcon.height(),
             bIcon.width(),
             bIcon.padding(),
-            bIcon.vBox()
+            bIcon.vBox(),
+            'toolbar-1x1'
           )
         }
         {
@@ -243,7 +257,8 @@ export default class FormatToolbar extends React.Component {
             iIcon.height(),
             iIcon.width(),
             iIcon.padding(),
-            iIcon.vBox()
+            iIcon.vBox(),
+            'toolbar-1x2'
           )
         }
         {
@@ -253,10 +268,11 @@ export default class FormatToolbar extends React.Component {
             uIcon.height(),
             uIcon.width(),
             uIcon.padding(),
-            uIcon.vBox()
+            uIcon.vBox(),
+            'toolbar-1x3'
           )
         }
-        <VertDivider />
+        <VertDivider className='toolbar-1x4'/>
         {
           this.renderMarkButton(
             cIcon.type(),
@@ -264,7 +280,8 @@ export default class FormatToolbar extends React.Component {
             cIcon.height(),
             cIcon.width(),
             cIcon.padding(),
-            cIcon.vBox()
+            cIcon.vBox(),
+            'toolbar-1x5'
           )
         }
         {
@@ -274,7 +291,8 @@ export default class FormatToolbar extends React.Component {
             qIcon.height(),
             qIcon.width(),
             qIcon.padding(),
-            qIcon.vBox()
+            qIcon.vBox(),
+            'toolbar-1x6'
           )
         }
         {
@@ -284,7 +302,8 @@ export default class FormatToolbar extends React.Component {
             ulIcon.height(),
             ulIcon.width(),
             ulIcon.padding(),
-            ulIcon.vBox()
+            ulIcon.vBox(),
+            'toolbar-1x7'
           )
         }
         {
@@ -294,10 +313,11 @@ export default class FormatToolbar extends React.Component {
             olIcon.height(),
             olIcon.width(),
             olIcon.padding(),
-            olIcon.vBox()
+            olIcon.vBox(),
+            'toolbar-1x8'
           )
         }
-        <VertDivider />
+        <VertDivider className='toolbar-1x9' />
         {
           this.renderMarkButton(
             pIcon.type(),
@@ -305,7 +325,8 @@ export default class FormatToolbar extends React.Component {
             pIcon.height(),
             pIcon.width(),
             pIcon.padding(),
-            pIcon.vBox()
+            pIcon.vBox(),
+            'toolbar-1x10'
           )
         }
         {
@@ -315,10 +336,11 @@ export default class FormatToolbar extends React.Component {
             lIcon.height(),
             lIcon.width(),
             lIcon.padding(),
-            lIcon.vBox()
+            lIcon.vBox(),
+            'toolbar-1x11'
           )
         }
-        <VertDivider />
+        <VertDividerResponsive className='toolbar-2x1' />
         {
           this.renderHistoryButton(
             unIcon.type(),
@@ -327,7 +349,8 @@ export default class FormatToolbar extends React.Component {
             unIcon.width(),
             unIcon.padding(),
             unIcon.vBox(),
-            'undo'
+            'undo',
+            'toolbar-2x2'
           )
       }
         {
@@ -338,11 +361,12 @@ export default class FormatToolbar extends React.Component {
             reIcon.width(),
             reIcon.padding(),
             reIcon.vBox(),
-            'redo'
+            'redo',
+            'toolbar-2x3'
           )
       }
         { pluginManager.renderToolbar(editor)}
-        <VertDivider />
+        <VertDivider className='toolbar-2x4'/>
       </StyledToolbar>,
       root,
     );

--- a/src/MarkdownEditor/index.js
+++ b/src/MarkdownEditor/index.js
@@ -42,10 +42,8 @@ const EditorWrapper = styled.div`
 `;
 
 const ToolbarWrapper = styled.div`
-  display: grid
-  grid-template-columns: 60% 40%;
-  grid-template-rows: 100%;
   height: 36px;
+  width: 100%;
   border: 1px solid #414F58;
   background: #FFFFFF;
   box-shadow: 0 1px 4px 0 rgba(0,0,0,0.1);

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -42,9 +42,6 @@ const EditorWrapper = styled.div`
 `;
 
 const ToolbarWrapper = styled.div`
-  display: grid
-  grid-template-columns: 60% 40%;
-  grid-template-rows: 100%;
   height: 36px;
   border: 1px solid #414F58;
   background: #FFFFFF;

--- a/src/styles.css
+++ b/src/styles.css
@@ -35,5 +35,44 @@ body {
   display: grid;
   justify-self: start;
   align-self: center;
-  grid-column-start: 2;
+  grid-column-start: 17;
+}
+
+#toolbarwrapperid {
+    display: grid;
+    grid-template-columns:
+        3% auto auto auto 
+        auto auto auto auto 
+        auto auto auto auto 
+        auto auto auto auto 
+        auto 130px 3%;
+    grid-template-rows: 100%;
+}
+
+@media (max-width: 1340px) {
+    .toolbarCheckbox {
+        grid-row-start: 2;
+        grid-column-start: 4;
+        justify-self: start;
+    }
+
+    #toolbarwrapperid {
+        height: 72px;
+        grid-template-columns: 3% 23.5% 23.5% 23.5% 23.5% 3%;
+        grid-template-rows: 50% 50%;
+    }
+}
+
+@media (max-width: 1050px) {
+    .toolbarCheckbox {
+        grid-row-start: 4;
+        grid-column: 2 / 5;
+        justify-self: center;
+    }
+
+    #toolbarwrapperid {
+        height: 140px;
+        grid-template-columns: 30% 10% 10% 10% 10% 30%;
+        grid-template-rows: 25% 25% 25% 25%;
+    }
 }

--- a/src/toolbar.css
+++ b/src/toolbar.css
@@ -1,0 +1,61 @@
+.format-toolbar {
+    display: grid;
+    grid-column-start: 2;
+    grid-row-start: 1 !important;
+  }
+  .toolbar-1x1 { grid-column-start: 2; }
+  .toolbar-1x2 { grid-column-start: 3; }  
+  .toolbar-1x3 { grid-column-start: 4; }  
+  .toolbar-1x4 { grid-column-start: 5; }  
+  .toolbar-1x5 { grid-column-start: 6; }  
+  .toolbar-1x6 { grid-column-start: 7; }  
+  .toolbar-1x7 { grid-column-start: 8; }  
+  .toolbar-1x8 { grid-column-start: 9; }  
+  .toolbar-1x9 { grid-column-start: 10; }  
+  .toolbar-1x10 { grid-column-start: 11; }
+  .toolbar-1x11 { grid-column-start: 12; }
+  .toolbar-2x1 { grid-column-start: 13; }
+  .toolbar-2x2 { grid-column-start: 14; }
+  .toolbar-2x3 { grid-column-start: 15; }
+  .toolbar-2x4 { grid-column-start: 17; }
+
+@media (max-width: 1340px) {
+    .format-toolbar {
+        grid-column: 2 / 6;
+        grid-template-rows: 100%;
+        justify-self: center !important;
+        gap: 5px 0px;
+    }
+    .toolbar-1x1 { grid-column-start: 1 !important; grid-row-start: 1 !important; }
+    .toolbar-1x2 { grid-column-start: 2 !important; grid-row-start: 1 !important; }  
+    .toolbar-1x3 { grid-column-start: 3 !important; grid-row-start: 1 !important; }  
+    .toolbar-1x4 { grid-column-start: 4 !important; grid-row-start: 1 !important; }  
+    .toolbar-1x5 { grid-column-start: 5 !important; grid-row-start: 1 !important; }  
+    .toolbar-1x6 { grid-column-start: 6 !important; grid-row-start: 1 !important; }  
+    .toolbar-1x7 { grid-column-start: 7 !important; grid-row-start: 1 !important; }  
+    .toolbar-1x8 { grid-column-start: 8 !important; grid-row-start: 1 !important; }  
+    .toolbar-1x9 { grid-column-start: 9 !important; grid-row-start: 1 !important; }  
+    .toolbar-1x10 { grid-column-start: 10 !important; grid-row-start: 1 !important; }
+    .toolbar-1x11 { grid-column-start: 11 !important; grid-row-start: 1 !important; }
+    .toolbar-2x2 { grid-column-start: 2 !important; grid-row-start: 2 !important; }
+    .toolbar-2x3 { grid-column-start: 3 !important; grid-row-start: 2 !important; }
+    .toolbar-2x4 { grid-column-start: 4 !important; grid-row-start: 2 !important; }
+}
+
+@media (max-width: 1050px) {
+    .format-toolbar {
+        grid-column: 2 / 5;
+        width: 250px !important;
+    }
+    .toolbar-1x1 { grid-column-start: 2 !important; }
+    .toolbar-1x2 { grid-column-start: 3 !important; }  
+    .toolbar-1x3 { grid-column-start: 4 !important; }
+    .toolbar-1x5 { grid-column-start: 2 !important; grid-row-start: 2 !important; }  
+    .toolbar-1x6 { grid-column-start: 3 !important; grid-row-start: 2 !important; }  
+    .toolbar-1x7 { grid-column-start: 4 !important; grid-row-start: 2 !important; }  
+    .toolbar-1x8 { grid-column-start: 5 !important; grid-row-start: 2 !important; }  
+    .toolbar-1x10 { grid-column-start: 2 !important; grid-row-start: 3 !important; }
+    .toolbar-1x11 { grid-column-start: 3 !important; grid-row-start: 3 !important; }
+    .toolbar-2x2 { grid-column-start: 4 !important; grid-row-start: 3 !important; }
+    .toolbar-2x3 { grid-column-start: 5 !important; grid-row-start: 3 !important; }
+}


### PR DESCRIPTION
# Issue #48 

### Changes
- CSS Grid
  - Initialize grid css for toolbar 
  - Improve grid css for main component
  - Remove unnecessary grid css from both slate editor and markdown editor
  - Enable classes for css and disable responsive vertical divider

### Flags
- Will need further customization with Header button.
- Possible conflicts with how the editor has been split.