### PR TITLE
refactor(*): refactor editors to use props instead of setting state

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -7,6 +7,8 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import MarkdownAsInputEditor from '../../src/MarkdownAsInputEditor';
 import SlateAsInputEditor from '../../src/SlateAsInputEditor';
+import PluginManager from '../../src/PluginManager';
+import FromMarkdown from '../../src/markdown/fromMarkdown';
 
 import * as serviceWorker from './serviceWorker';
 import 'semantic-ui-css/semantic.min.css';
@@ -62,7 +64,10 @@ function Demo() {
   /**
    * Current Slate Value
    */
-  const [slateValue, setSlateValue] = useState();
+  const pluginManager = new PluginManager(plugins);
+  const fromMarkdown = new FromMarkdown(pluginManager);
+  const [slateValue, setSlateValue] = useState(fromMarkdown.convert(defaultMarkdown));
+  const [markdown, setMarkdown] = useState(defaultMarkdown);
 
   /**
    * Called when the markdown changes
@@ -71,6 +76,7 @@ function Demo() {
     localStorage.setItem('markdown-editor', markdown);
     console.log('onMarkdownChange', markdown);
     setSlateValue(slateValue);
+    setMarkdown(markdown);
   }, []);
 
   /**
@@ -86,7 +92,7 @@ function Demo() {
       <Segment>
     <Grid columns={2}>
       <Grid.Column>
-        <MarkdownAsInputEditor plugins={plugins} markdown={defaultMarkdown} onChange={onMarkdownChange}/>
+        <MarkdownAsInputEditor plugins={plugins} markdown={markdown} onChange={onMarkdownChange}/>
       </Grid.Column>
 
       <Grid.Column>

--- a/src/MarkdownAsInputEditor/index.js
+++ b/src/MarkdownAsInputEditor/index.js
@@ -39,6 +39,13 @@ function MarkdownAsInputEditor(props) {
     onChange, plugins
   } = props;
 
+  const onChangeHandler = (evt) => {
+    const pluginManager = new PluginManager(plugins);
+    const fromMarkdown = new FromMarkdown(pluginManager);
+    const newSlateValue = fromMarkdown.convert(evt.target.value);
+    onChange(newSlateValue, evt.target.value);
+  };
+
   /**
    * Render the component, based on showSlate
    */
@@ -50,12 +57,7 @@ function MarkdownAsInputEditor(props) {
     placeholder={props.markdown}
     value={props.markdown}
     // eslint-disable-next-line no-unused-vars
-    onChange={(evt, data) => {
-      const pluginManager = new PluginManager(plugins);
-      const fromMarkdown = new FromMarkdown(pluginManager);
-      const newSlateValue = fromMarkdown.convert(evt.target.value);
-      onChange(newSlateValue, evt.target.value);
-    }}
+    onChange={onChangeHandler}
   />
   </Card.Content>
 </Card>;

--- a/src/MarkdownAsInputEditor/index.js
+++ b/src/MarkdownAsInputEditor/index.js
@@ -14,7 +14,6 @@
 
 import React, {
   useEffect,
-  useState,
 }
   from 'react';
 import { Card } from 'semantic-ui-react';
@@ -34,11 +33,6 @@ import '../styles.css';
  */
 function MarkdownAsInputEditor(props) {
   /**
-   * Current Markdown text
-   */
-  const [markdown, setMarkdown] = useState(props.markdown);
-
-  /**
    * Destructure props for efficiency
    */
   const {
@@ -46,30 +40,23 @@ function MarkdownAsInputEditor(props) {
   } = props;
 
   /**
-   * Call onChange with the Slate Value when the markdown or the plugins change
-   */
-  useEffect(() => {
-    const pluginManager = new PluginManager(plugins);
-    const fromMarkdown = new FromMarkdown(pluginManager);
-    const newSlateValue = fromMarkdown.convert(markdown);
-    onChange(newSlateValue, markdown);
-  }, [markdown, onChange, plugins]);
-
-  /**
    * Render the component, based on showSlate
    */
   const card = <Card fluid>
   <Card.Content>
   <TextareaAutosize
-                className={'textarea'}
-                width={'100%'}
-                placeholder={props.markdown}
-                value={markdown}
-                // eslint-disable-next-line no-unused-vars
-                onChange={(evt, data) => {
-                  setMarkdown(evt.target.value);
-                }}
-              />
+    className={'textarea'}
+    width={'100%'}
+    placeholder={props.markdown}
+    value={props.markdown}
+    // eslint-disable-next-line no-unused-vars
+    onChange={(evt, data) => {
+      const pluginManager = new PluginManager(plugins);
+      const fromMarkdown = new FromMarkdown(pluginManager);
+      const newSlateValue = fromMarkdown.convert(evt.target.value);
+      onChange(newSlateValue, evt.target.value);
+    }}
+  />
   </Card.Content>
 </Card>;
 
@@ -114,6 +101,13 @@ MarkdownAsInputEditor.propTypes = {
     markdownTags: PropTypes.arrayOf(PropTypes.string).isRequired,
     schema: PropTypes.object.isRequired,
   })),
+};
+
+/**
+ * The default property values for this component
+ */
+MarkdownAsInputEditor.defaultProps = {
+  value: 'Welcome! Edit this text to begin.'
 };
 
 export default MarkdownAsInputEditor;

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -496,6 +496,13 @@ function SlateAsInputEditor(props) {
     );
   }, []);
 
+  const onChangeHandler = ({ value }) => {
+    const pluginManager = new PluginManager(plugins);
+    const toMarkdown = new ToMarkdown(pluginManager);
+    const newMarkdown = toMarkdown.convert(value);
+    onChange(value, newMarkdown);
+  };
+
   return (
     <div>
       <ToolbarWrapper id="toolbarwrapperid" />
@@ -508,12 +515,7 @@ function SlateAsInputEditor(props) {
                 className="doc-inner"
                 value={Value.fromJSON(value)}
                 readOnly={props.readOnly}
-                onChange={({ value }) => {
-                  const pluginManager = new PluginManager(plugins);
-                  const toMarkdown = new ToMarkdown(pluginManager);
-                  const newMarkdown = toMarkdown.convert(value);
-                  onChange(value, newMarkdown);
-                }}
+                onChange={onChangeHandler}
                 schema={slateSchema}
                 plugins={props.plugins}
                 onBeforeInput={onBeforeInput}

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -506,7 +506,7 @@ function SlateAsInputEditor(props) {
               <Editor
                 ref={editorRef}
                 className="doc-inner"
-                value={value}
+                value={Value.fromJSON(value)}
                 readOnly={props.readOnly}
                 onChange={({ value }) => {
                   const pluginManager = new PluginManager(plugins);

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -63,9 +63,6 @@ const ToolbarWrapper = styled.div`
   margin-bottom: 1px;
 `;
 
-// @ts-ignore
-const defaultValue = Value.fromJSON(initialValue);
-
 /**
  * a utility function to generate a random node id for annotations
  */
@@ -110,14 +107,6 @@ function SlateAsInputEditor(props) {
   const editorRef = useRef(null);
 
   /**
-   * Current Slate Value
-   */
-  const [
-    slateValue,
-    setSlateValue
-  ] = useState(props.value ? Value.fromJSON(props.value) : defaultValue);
-
-  /**
    * Slate Schema augmented by plugins
    */
   const [slateSchema, setSlateSchema] = useState(null);
@@ -148,24 +137,6 @@ function SlateAsInputEditor(props) {
   }, [plugins]);
 
   /**
-   * Calls onChange with the modified markdown when the
-   * Slate Value or the plugins change
-   */
-  useEffect(() => {
-    const pluginManager = new PluginManager(plugins);
-    const toMarkdown = new ToMarkdown(pluginManager);
-    const newMarkdown = toMarkdown.convert(slateValue);
-    onChange(slateValue, newMarkdown);
-  }, [onChange, plugins, slateValue]);
-
-  /**
-   * Updates the Slate value in state when props.value changes
-   */
-  useEffect(() => {
-    setSlateValue(value ? Value.fromJSON(value) : defaultValue);
-  }, [value]);
-
-  /**
    * Set a lockText annotation on the editor equal to props.lockText
    */
   useEffect(() => {
@@ -193,7 +164,7 @@ function SlateAsInputEditor(props) {
         }
       });
     }
-  }, [slateValue.document, lockText]);
+  }, [value.document, lockText]);
 
   /**
    * When the Slate Value changes changes update the variable annotations.
@@ -248,7 +219,7 @@ function SlateAsInputEditor(props) {
       }
     }
   // @ts-ignore
-  }, [editorRef, isEditorLockText, lockText, slateValue.document]);
+  }, [editorRef, isEditorLockText, lockText, value.document]);
 
   /**
    * Render a Slate inline.
@@ -535,10 +506,13 @@ function SlateAsInputEditor(props) {
               <Editor
                 ref={editorRef}
                 className="doc-inner"
-                value={slateValue}
+                value={value}
                 readOnly={props.readOnly}
                 onChange={({ value }) => {
-                  setSlateValue(value);
+                  const pluginManager = new PluginManager(plugins);
+                  const toMarkdown = new ToMarkdown(pluginManager);
+                  const newMarkdown = toMarkdown.convert(value);
+                  onChange(value, newMarkdown);
                 }}
                 schema={slateSchema}
                 plugins={props.plugins}
@@ -602,10 +576,28 @@ SlateAsInputEditor.propTypes = {
     schema: PropTypes.object.isRequired,
   })),
 };
+
 /**
  * The default property values for this component
  */
 SlateAsInputEditor.defaultProps = {
+  value: Value.fromJSON({
+    object: 'value',
+    document: {
+      object: 'document',
+      data: {},
+      nodes: [{
+        object: 'block',
+        type: 'paragraph',
+        data: {},
+        nodes: [{
+          object: 'text',
+          text: 'Welcome! Edit this text to get started.',
+          marks: []
+        }],
+      }]
+    }
+  })
 };
 
 export default SlateAsInputEditor;


### PR DESCRIPTION
refactor(SlateAsInputEditor): refactor to always use props instead of setting state for slate val
refactor(MarkdownAsInputEditor): refactor to use props instead of setting state for md
fix(examples): update example demo based on changes