### PR TITLE
(fix) allow plugins to extend schema

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -130,10 +130,28 @@ function SlateAsInputEditor(props) {
   useEffect(() => {
     const schema = JSON.parse(JSON.stringify(baseSchema));
     plugins.forEach((plugin) => {
+      // add all markdown tags to the root of the document
       plugin.tags.forEach((tag) => {
         schema.document.nodes[0].match.push({ type: tag.slate });
       });
+
+      // merge the rest of the elements into the schema
+      const pluginSchema = plugin.schema;
+      if (pluginSchema) {
+        if (pluginSchema.blocks) {
+          schema.blocks = { ...schema.blocks, ...pluginSchema.blocks };
+        }
+
+        if (pluginSchema.inlines) {
+          schema.inlines = { ...schema.inlines, ...pluginSchema.inlines };
+        }
+
+        if (pluginSchema.rules) {
+          schema.rules = schema.rules.concat(pluginSchema.rules);
+        }
+      }
     });
+    console.log(schema);
     setSlateSchema(schema);
   }, [plugins]);
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -22,6 +22,9 @@ const schema = {
       },
     ],
   },
+  inlines: {
+  },
+  rules: [],
   blocks: {
     paragraph: {
       nodes: [


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

This fix allows plugins to extend the Slate schema (to define custom block types, inlines, rules).