### PR TITLE
fix(icons): sync sizing for all toolbar icons - I62

### DIFF
--- a/src/icons/OL.js
+++ b/src/icons/OL.js
@@ -3,9 +3,9 @@ import React from 'react';
 // may need to change this type value to 'list' or 'ol'
 export const type = () => 'ol_list';
 
-export const height = () => '24px';
+export const height = () => '25px';
 
-export const width = () => '23px';
+export const width = () => '25px';
 
 export const padding = () => '5px 3px';
 

--- a/src/icons/UL.js
+++ b/src/icons/UL.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 export const type = () => 'ul_list';
 
-export const height = () => '24px';
+export const height = () => '25px';
 
-export const width = () => '24px';
+export const width = () => '25px';
 
 export const padding = () => '5px 4px';
 

--- a/src/icons/bold.js
+++ b/src/icons/bold.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const type = () => 'bold';
 
-export const height = () => '23px';
+export const height = () => '25px';
 
 export const width = () => '25px';
 

--- a/src/icons/code.js
+++ b/src/icons/code.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 export const type = () => 'code';
 
-export const height = () => '24px';
+export const height = () => '25px';
 
-export const width = () => '24px';
+export const width = () => '25px';
 
 export const padding = () => '4px 2px';
 

--- a/src/icons/hyperlink.js
+++ b/src/icons/hyperlink.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 export const type = () => 'link';
 
-export const height = () => '24px';
+export const height = () => '25px';
 
-export const width = () => '24px';
+export const width = () => '25px';
 
 export const padding = () => '5px 5px';
 

--- a/src/icons/italic.js
+++ b/src/icons/italic.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 export const type = () => 'italic';
 
-export const height = () => '23px';
+export const height = () => '25px';
 
-export const width = () => '24px';
+export const width = () => '25px';
 
 export const padding = () => '5px 7px';
 

--- a/src/icons/navigation-left.js
+++ b/src/icons/navigation-left.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 export const type = () => 'bold';
 
-export const height = () => '23px';
+export const height = () => '25px';
 
-export const width = () => '24px';
+export const width = () => '25px';
 
 export const padding = () => '6px 4px';
 

--- a/src/icons/navigation-right.js
+++ b/src/icons/navigation-right.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 export const type = () => 'bold';
 
-export const height = () => '23px';
+export const height = () => '25px';
 
-export const width = () => '24px';
+export const width = () => '25px';
 
 export const padding = () => '6px 4px';
 

--- a/src/icons/open-quote.js
+++ b/src/icons/open-quote.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 export const type = () => 'block_quote';
 
-export const height = () => '23px';
+export const height = () => '25px';
 
-export const width = () => '24px';
+export const width = () => '25px';
 
 export const padding = () => '5px 3px';
 

--- a/src/icons/param.js
+++ b/src/icons/param.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const type = () => 'variable';
 
-export const height = () => '24px';
+export const height = () => '25px';
 
 export const width = () => '25px';
 

--- a/src/icons/underline.js
+++ b/src/icons/underline.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const type = () => 'underline';
 
-export const height = () => '23px';
+export const height = () => '25px';
 
 export const width = () => '25px';
 


### PR DESCRIPTION
# Issue #62
Correct toolbar icons misalignment in Safari

### Changes
- Synchronize height and width of all icons

### Flags
- These alignments (viewBox, height, width, padding) were quite finicky for each individual icon when first created, take a look to ensure they appear correct

### Related Issues
- [Cicero UI 63](https://github.com/accordproject/cicero-ui/issues/63)