### PR TITLE
Fix list blocks register as hyperlink (#84)

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -248,7 +248,7 @@ export default class FormatToolbar extends React.Component {
   renderLinkButton(type, icon, hi, wi, pa, vBox, classInput) {
     const { editor, editorProps } = this.props;
 
-    const isActive = action.getSelectedListBlock(editor);
+    const isActive = action.hasLinks(editor);
 
     const fillActivity = isActive
       ? '#2587DA'


### PR DESCRIPTION
Signed-off-by: sgbj <scott.batary@gmail.com>

# Issue #84 
Creating a bulleted list marks a block as a hyperlink in the formatting toolbar.

### Changes
- The code for rendering the link button was previously using `action.getSelectedListBlock(editor)` to determine whether the button should be marked as active. This has been changed to `action.hasLinks(editor)`.

### Flags
- None

### Related Issues
- None