### PR TITLE
docs(README): fix typo - I104

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Your app is ready to be deployed!
 
 ## Styling
 
-You can style the toolbar of this components, as well as the width of the editor:
+You can style the toolbar of this component, as well as the width of the editor:
 
 #### `editorProps`
 


### PR DESCRIPTION
issue #104 

Signed-off-by: Parikshit Hooda <phooda804@live.com>

# Issue #104 
changed the word 'components' to 'component' in README.md

### Changes
- changed the word 'components' to 'component' in README.md


### Flags
- <DESCRIBE ISSUES OR HOLDS FOR REVIEWERS>

### Related Issues
- Issue #104 
- Pull Request #<NUMBER HERE>