### PR TITLE
Hyperlink tooltip

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Dropdown, Popup } from 'semantic-ui-react';
+import { Dropdown, Popup, Form, Button} from 'semantic-ui-react';
 
 import * as action from './toolbarMethods';
 import * as styles from './toolbarStyles';
@@ -88,6 +88,17 @@ const DropdownHeader3 = {
 };
 
 export default class FormatToolbar extends React.Component {
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      linkText: '',
+      linkURL: '',
+    }
+  }
+
+
   /**
    * When a mark button is clicked, toggle undo or redo.
    */
@@ -329,7 +340,7 @@ export default class FormatToolbar extends React.Component {
     if (!root) { return null; }
 
     return ReactDOM.createPortal(
-      <StyledToolbar background={editorProps.TOOLBAR_BACKGROUND} className="format-toolbar">
+      <StyledToolbar background={editorProps.TOOLBAR_BACKGROUND} className='format-toolbar'>
         <Dropdown
           text='Style'
           className='toolbar-0x0'
@@ -439,17 +450,93 @@ export default class FormatToolbar extends React.Component {
           )
         }
         <VertDivider color={editorProps.DIVIDER} className='toolbar-4x2' />
-        {
-          this.renderLinkButton(
-            hyperlinkIcon.type(),
-            hyperlinkIcon.icon,
-            hyperlinkIcon.height(),
-            hyperlinkIcon.width(),
-            hyperlinkIcon.padding(),
-            hyperlinkIcon.vBox(),
-            'toolbar-2x1'
-          )
-        }
+        <Dropdown
+          icon={
+            <ToolbarIcon
+              aria-label={hyperlinkIcon.type()}
+              background={
+                action.hasMark(this.props.editor, hyperlinkIcon.type())
+                  ? styles.buttonBgActive(editorProps.BUTTON_BACKGROUND_ACTIVE)
+                  : styles.buttonBgInactiveInactive(
+                      editorProps.BUTTON_BACKGROUND_INACTIVE
+                    )
+              }
+              width={hyperlinkIcon.width()}
+              height={hyperlinkIcon.height()}
+              padding={hyperlinkIcon.padding()}
+              viewBox={hyperlinkIcon.vBox()}
+              className={'toolbar-2x1'}
+            >
+              {hyperlinkIcon.icon(
+                action.hasMark(this.props.editor, hyperlinkIcon.type())
+                  ? styles.buttonSymbolActive(editorProps.BUTTON_SYMBOL_ACTIVE)
+                  : styles.buttonSymbolInactive(
+                      editorProps.BUTTON_SYMBOL_INACTIVE
+                    )
+              )}
+            </ToolbarIcon>
+          }
+          className='toolbar-2x1'
+          openOnFocus
+          simple
+          style={new DropdownStyle(editorProps.DROPDOWN_COLOR)}
+        >
+          <Dropdown.Menu>
+            <Dropdown.Item>
+              <Form>
+                {!editor.value.selection.isExpanded ? (
+                  <Form.Field>
+                    <label>Enter the text for the link:</label>
+                    <input
+                      placeholder='text'
+                      value={this.state.linkText}
+                      onChange={e =>
+                        this.setState({
+                          ...this.state,
+                          linkText: e.target.value
+                        })
+                      }
+                    />
+                  </Form.Field>
+                ) : null}
+                <Form.Field>
+                  <label>Enter the URL of the link:</label>
+                  <input
+                    placeholder='URL'
+                    value={this.state.linkURL}
+                    onChange={e =>
+                      this.setState({ ...this.state, linkURL: e.target.value })
+                    }
+                  />
+                </Form.Field>
+                <Button
+                  primary
+                  type='submit'
+                  onClick={event => {
+                    action.onClickLink(
+                      event,
+                      this.props.editor,
+                      this.state.linkText,
+                      this.state.linkURL
+                    );
+                    this.setState({ linkURL: '', linkText: '' });
+                  }}
+                >
+                  Save
+                </Button>
+                <Button
+                  secondary
+                  type='reset'
+                  onClick={() => {
+                    this.setState({ linkURL: '', linkText: '' });
+                  }}
+                >
+                  Clear
+                </Button>
+              </Form>
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
         <VertDivider color={editorProps.DIVIDER} className='toolbar-4x3' />
         {
           this.renderHistoryButton(

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -486,9 +486,9 @@ export default class FormatToolbar extends React.Component {
               <Form>
                 {!editor.value.selection.isExpanded ? (
                   <Form.Field>
-                    <label>Enter the text for the link:</label>
+                    <label>Link Text:</label>
                     <input
-                      placeholder='text'
+                      placeholder='Text'
                       value={this.state.linkText}
                       onChange={e =>
                         this.setState({
@@ -500,9 +500,9 @@ export default class FormatToolbar extends React.Component {
                   </Form.Field>
                 ) : null}
                 <Form.Field>
-                  <label>Enter the URL of the link:</label>
+                  <label>Link URL:</label>
                   <input
-                    placeholder='URL'
+                    placeholder='https://example.com'
                     value={this.state.linkURL}
                     onChange={e =>
                       this.setState({ ...this.state, linkURL: e.target.value })

--- a/src/FormattingToolbar/toolbarMethods.js
+++ b/src/FormattingToolbar/toolbarMethods.js
@@ -114,30 +114,23 @@ export const hasBlock = (editor, type) => {
    * When clicking a link, if the selection has a link in it, remove the link.
    * Otherwise, add a new link with an href and text.
    */
-export const onClickLink = (event, editor) => {
+export const onClickLink = (event, editor, text, href) => {
   event.preventDefault();
-
   const { value } = editor;
   const hasLinksBool = hasLinks(editor);
-
   if (hasLinksBool) {
     editor.command(unwrapLink);
-  } else if (value.selection.isExpanded) {
-    const href = window.prompt('Enter the URL of the link:');
-
+  }
+  if (value.selection.isExpanded) {
     if (href === null) {
       return;
     }
 
     editor.command(wrapLink, href);
   } else {
-    const href = window.prompt('Enter the URL of the link:');
-
     if (href === null) {
       return;
     }
-
-    const text = window.prompt('Enter the text for the link:');
 
     if (text === null) {
       return;


### PR DESCRIPTION
### Issue #100 
This PR replaces the JavaScript `alert` used when adding a hyperlink with a new tooltip as requested in the issue.

---

### Changes

#### Old hyperlink input prompt:

-  _Text:_

    ![text](https://user-images.githubusercontent.com/20889958/66263440-f92ba600-e7f2-11e9-8be1-30a08a30aa3a.PNG)

- _URL:_

    ![link](https://user-images.githubusercontent.com/20889958/66263442-fcbf2d00-e7f2-11e9-91c5-f644c19757d8.PNG)

#### New input prompt:

- _Text & URL:_

    ![Screenshot (16)](https://user-images.githubusercontent.com/20889958/66263449-2d06cb80-e7f3-11e9-98d4-59b9c6c1acd5.png)
