### PR TITLE
Adding readOnlyToolbar prop for toolbar rendering

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import {
-  Divider, Grid, Segment
+  Button, Divider, Grid, Segment
 } from 'semantic-ui-react';
 
 import ReactDOM from 'react-dom';
@@ -61,6 +61,7 @@ function Demo() {
    */
   const [slateValue, setSlateValue] = useState(slateTransformer.fromMarkdown(defaultMarkdown));
   const [markdown, setMarkdown] = useState(defaultMarkdown);
+  const [display, setDisplay] = useState(false);
 
   /**
    * Called when the markdown changes
@@ -81,6 +82,7 @@ function Demo() {
 
   return (
     <div>
+      
       <Segment>
     <Grid columns={2}>
       <Grid.Column>
@@ -88,7 +90,8 @@ function Demo() {
       </Grid.Column>
 
       <Grid.Column>
-      <SlateAsInputEditor readOnly={false} lockText={true} plugins={plugins} value={slateValue} onChange={onSlateValueChange} editorProps={propsObj} />
+        <Button onClick={() => setDisplay(!display)}>TOGGLE READONLY</Button>
+        <SlateAsInputEditor key={display} readOnly={display} lockText={true} plugins={plugins} value={slateValue} onChange={onSlateValueChange} editorProps={propsObj} />
       </Grid.Column>
     </Grid>
     <Divider vertical>Preview</Divider>

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -88,7 +88,7 @@ function Demo() {
       </Grid.Column>
 
       <Grid.Column>
-      <SlateAsInputEditor readOnly={false} readOnlyToolbar={false} lockText={true} plugins={plugins} value={slateValue} onChange={onSlateValueChange} editorProps={propsObj} />
+      <SlateAsInputEditor readOnly={false} lockText={true} plugins={plugins} value={slateValue} onChange={onSlateValueChange} editorProps={propsObj} />
       </Grid.Column>
     </Grid>
     <Divider vertical>Preview</Divider>

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -88,7 +88,7 @@ function Demo() {
       </Grid.Column>
 
       <Grid.Column>
-        <SlateAsInputEditor readOnly={false} lockText={true} plugins={plugins} value={slateValue} onChange={onSlateValueChange} editorProps={propsObj} />
+      <SlateAsInputEditor readOnly={false} readOnlyToolbar={false} lockText={true} plugins={plugins} value={slateValue} onChange={onSlateValueChange} editorProps={propsObj} />
       </Grid.Column>
     </Grid>
     <Divider vertical>Preview</Divider>

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -428,7 +428,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
 
   return (
     <div>
-      <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" className={(props.readOnlyToolbar ? 'toolbar-readonly' : '')} />
+      { props.readOnly ? '' : <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" /> }
       <EditorWrapper width={editorProps.WIDTH}>
         <Editor
           ref={editorRef}
@@ -492,12 +492,6 @@ SlateAsInputEditor.propTypes = {
    * When set to the true the contents of the editor are read-only
    */
   readOnly: PropTypes.bool,
-
-  /**
-   * When set to the true the contents of the toolbar are read-only
-   */
-  readOnlyToolbar: PropTypes.bool,
-
 
   /**
    * An array of plugins to extend the functionality of the editor

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -428,7 +428,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
 
   return (
     <div>
-      <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" />
+      <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" className={(props.readOnlyToolbar ? 'toolbar-readonly' : '')} />
       <EditorWrapper width={editorProps.WIDTH}>
         <Editor
           ref={editorRef}
@@ -492,6 +492,12 @@ SlateAsInputEditor.propTypes = {
    * When set to the true the contents of the editor are read-only
    */
   readOnly: PropTypes.bool,
+
+  /**
+   * When set to the true the contents of the toolbar are read-only
+   */
+  readOnlyToolbar: PropTypes.bool,
+
 
   /**
    * An array of plugins to extend the functionality of the editor

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -428,7 +428,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
 
   return (
     <div>
-      { props.readOnly ? '' : <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" /> }
+      { !props.readOnly && <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" /> }
       <EditorWrapper width={editorProps.WIDTH}>
         <Editor
           ref={editorRef}

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,3 +32,7 @@ body {
     grid-template-columns: 3% auto 3%;
     grid-template-rows: 100%;
 }
+
+.toolbar-readonly {
+    pointer-events: none;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,7 +32,3 @@ body {
     grid-template-columns: 3% auto 3%;
     grid-template-rows: 100%;
 }
-
-.toolbar-readonly {
-    pointer-events: none;
-}


### PR DESCRIPTION
# Issue #79
This PR adds a new props readOnlyToolbar which will make the toolbar readonly just like the Editor.

### Changes
- Added new prop readOnlyToolbar 
  - Based on readOnlyToolbar, adding a class which will make the toolbar readonly 
  - Added a new class in style.css