### PR TITLE
feat(*): add styling for blockquote - I102

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ This is an object with the following possible css inputs as strings:
 - `TOOLTIP`
 - `TOOLBAR_SHADOW`
 - `WIDTH`
+- `BLOCKQUOTE`
+  - `FONT_FAMILY`
+  - `FONT_COLOR`
+  - `FONT_STYLE`
+  - `FONT_WEIGHT`
+  - `QUOTE_COLOR`
+  - `FONT_SIZE`
 
 ---
 

--- a/examples/src/index.css
+++ b/examples/src/index.css
@@ -38,7 +38,7 @@ blockquote {
 	width: 80%;
 	margin: 10px auto;
 	padding: 1.0em 10px 1.2em 15px;
-	border-left: 5px solid #484848;
+	border-left: 3px solid #484848;
 	line-height: 1;
 	position: relative;
 }

--- a/examples/src/index.css
+++ b/examples/src/index.css
@@ -35,16 +35,12 @@ html {
 }
 
 blockquote {
-	font-size: 1em;
 	width: 80%;
 	margin: 10px auto;
-	font-family: Open Sans;
-	font-style: italic;
 	padding: 1.0em 10px 1.2em 15px;
 	border-left: 5px solid #484848;
 	line-height: 1;
 	position: relative;
-	font-style: italic !important;
 }
 
 a {
@@ -54,7 +50,6 @@ a {
 blockquote::before {
 	font-family: Arial;
 	content: '\201C';
-	color: #484848;
 	font-size: 1em;
 	position: absolute;
 	left: 5px;
@@ -66,10 +61,6 @@ blockquote::after {
 }
 
 blockquote span {
-	display: block;
-	color: #333333;
-	font-style: normal;
-	font-weight: bold;
 	margin-top: 1em;
 }
 

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -75,6 +75,21 @@ Heading.propTypes = {
   type: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
 };
 
+const Blockquote = ({ children, attributes, blockQuoteStyle }) => createElement(
+  styled.blockquote`
+    font-size: ${blockQuoteStyle && blockQuoteStyle.FONT_SIZE ? blockQuoteStyle.FONT_SIZE : '1em' };
+    font-family: ${blockQuoteStyle && blockQuoteStyle.FONT_FAMILY ? blockQuoteStyle.FONT_FAMILY : 'Open Sans' };
+    font-style: ${blockQuoteStyle && blockQuoteStyle.FONT_STYLE ? blockQuoteStyle.FONT_STYLE : 'italic !important' };
+    font-weight: ${blockQuoteStyle && blockQuoteStyle.FONT_WEIGHT ? blockQuoteStyle.FONT_WEIGHT : '400' };
+    color: ${blockQuoteStyle && blockQuoteStyle.FONT_COLOR ? blockQuoteStyle.FONT_COLOR : '#333333' };
+    ::before {
+      color: ${blockQuoteStyle && blockQuoteStyle.QUOTE_COLOR ? blockQuoteStyle.QUOTE_COLOR : '#484848' };
+    }
+  `,
+  attributes,
+  children,
+);
+
 /**
  * a utility function to generate a random node id for annotations
  */
@@ -214,6 +229,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
   // @ts-ignore
   const renderBlock = useCallback((props, editor, next) => {
     const { node, attributes, children } = props;
+    const { editorProps } = editor.props;
 
     switch (node.type) {
       case 'paragraph':
@@ -233,7 +249,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
       case 'horizontal_rule':
         return <hr {...attributes} />;
       case 'block_quote':
-        return <blockquote {...attributes}>{children}</blockquote>;
+        return <Blockquote children={children} attributes={attributes} blockQuoteStyle={editorProps.BLOCKQUOTE} />;
       case 'code_block':
         return <pre {...attributes}>{children}</pre>;
       case 'html_block':
@@ -475,6 +491,14 @@ SlateAsInputEditor.propTypes = {
     TOOLTIP: PropTypes.string,
     TOOLBAR_SHADOW: PropTypes.string,
     WIDTH: PropTypes.string,
+    BLOCKQUOTE: PropTypes.shape({
+      FONT_FAMILY: PropTypes.string,
+      FONT_COLOR: PropTypes.string,
+      FONT_SIZE: PropTypes.string,
+      FONT_STYLE: PropTypes.string,
+      FONT_WEIGHT: PropTypes.string,
+      QUOTE_COLOR: PropTypes.string,
+    })
   }),
 
   /**


### PR DESCRIPTION
# Issue #102
 Ability to style the blockquote text via a prop

### Changes
- Added `BLOCKQUOTE` prop under `editorProps`
  - `BLOCKQUOTE` prop can be used to style blockquotes in the document. `BLOCKQUOTE` prop supports following styles as of now: 

    - `FONT_FAMILY`
    - `FONT_COLOR`
    - `FONT_SIZE`
    - `FONT_STYLE`
    - `FONT_WEIGHT`
    - `QUOTE_COLOR`

Feature in action:

<img width="672" alt="Screen Shot 2019-10-15 at 1 11 17 AM" src="https://user-images.githubusercontent.com/9020200/66778235-bfd8f180-eee8-11e9-9ba9-86aa95923589.png">



### Flags
- The current props system for the blockquote is only for the text portion of the quote not for the entire quote itself, which includes styles for pseudoselectors.

### Related Issues
- Issue #102 