### PR TITLE
feat(SlateAsInputEditor): pass props down to slate Editor

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -218,17 +218,17 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
       case 'paragraph':
         return <p {...attributes}>{children}</p>;
       case 'heading_one':
-        return <Heading type="h1" children={children} {...attributes} />;
+        return <Heading type="h1" {...attributes}>{children}</Heading>;
       case 'heading_two':
-        return <Heading type="h2" children={children} {...attributes} />;
+        return <Heading type="h2" {...attributes}>{children}</Heading>;
       case 'heading_three':
-        return <Heading type="h3" children={children} {...attributes} />;
+        return <Heading type="h3" {...attributes}>{children}</Heading>;
       case 'heading_four':
-        return <Heading type="h4" children={children} {...attributes} />;
+        return <Heading type="h4" {...attributes}>{children}</Heading>;
       case 'heading_five':
-        return <Heading type="h5" children={children} {...attributes} />;
+        return <Heading type="h5" {...attributes}>{children}</Heading>;
       case 'heading_six':
-        return <Heading type="h6" children={children} {...attributes} />;
+        return <Heading type="h6" {...attributes}>{children}</Heading>;
       case 'horizontal_rule':
         return <hr {...attributes} />;
       case 'block_quote':

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -430,6 +430,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
       <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" />
       <EditorWrapper width={editorProps.WIDTH}>
         <Editor
+          {...props}
           ref={editorRef}
           className="doc-inner"
           value={Value.fromJSON(value)}
@@ -445,7 +446,6 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
           renderMark={renderMark}
           editorProps={editorProps}
           renderEditor={renderEditor}
-          clausePluginProps={props.clausePluginProps}
         />
       </EditorWrapper>
     </div>
@@ -475,21 +475,6 @@ SlateAsInputEditor.propTypes = {
     TOOLTIP: PropTypes.string,
     TOOLBAR_SHADOW: PropTypes.string,
     WIDTH: PropTypes.string,
-  }),
-
-  clausePluginProps: PropTypes.shape({
-    loadTemplateObject: PropTypes.func,
-    parseClause: PropTypes.func,
-    pasteToContract: PropTypes.func,
-    clauseProps: PropTypes.shape({
-      BODY_FONT: PropTypes.string,
-      CLAUSE_BACKGROUND: PropTypes.string,
-      CLAUSE_BORDER: PropTypes.string,
-      CLAUSE_DELETE: PropTypes.string,
-      CLAUSE_DELETE_FUNCTION: PropTypes.func,
-      HEADER_FONT: PropTypes.string,
-      HEADER_TITLE: PropTypes.string,
-    })
   }),
 
   /**

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -16,7 +16,7 @@ import React, {
   useEffect,
   useState,
   useRef,
-  useCallback, 
+  useCallback,
   createElement
 }
   from 'react';
@@ -62,14 +62,13 @@ const ToolbarWrapper = styled.div`
   box-shadow: ${props => props.TOOLBAR_SHADOW || 'none'};
 `;
 
-const Heading = ({ type, children }) =>
-  createElement(
-    styled(type)`
+const Heading = ({ type, children }) => createElement(
+  styled(type)`
       font-family: 'serif';
     `,
-    {},
-    children,
-  );
+  {},
+  children,
+);
 
 Heading.propTypes = {
   type: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
@@ -446,6 +445,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
           renderMark={renderMark}
           editorProps={editorProps}
           renderEditor={renderEditor}
+          clausePluginProps={props.clausePluginProps}
         />
       </EditorWrapper>
     </div>
@@ -475,6 +475,21 @@ SlateAsInputEditor.propTypes = {
     TOOLTIP: PropTypes.string,
     TOOLBAR_SHADOW: PropTypes.string,
     WIDTH: PropTypes.string,
+  }),
+
+  clausePluginProps: PropTypes.shape({
+    loadTemplateObject: PropTypes.func,
+    parseClause: PropTypes.func,
+    pasteToContract: PropTypes.func,
+    clauseProps: PropTypes.shape({
+      BODY_FONT: PropTypes.string,
+      CLAUSE_BACKGROUND: PropTypes.string,
+      CLAUSE_BORDER: PropTypes.string,
+      CLAUSE_DELETE: PropTypes.string,
+      CLAUSE_DELETE_FUNCTION: PropTypes.func,
+      HEADER_FONT: PropTypes.string,
+      HEADER_TITLE: PropTypes.string,
+    })
   }),
 
   /**


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

### Changes
- feat(SlateAsInputEditor): pass props down to slate Editor
- this way, any props passed to SlateAsInputEditor will also get passed to the Editor from Slate
