### PR TITLE
Polished border and added drop show to markdown editor

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -37,7 +37,7 @@ const EditorWrapper = styled.div`
   max-width: ${props => props.width || 'none'};
   min-width: ${props => props.width || 'none'};
   border: 1px solid #979797;
-  border-radius: 10px;
+  box-shadow: 1px 2px 4px rgba(0, 0, 0, .5);
   margin: 50px auto;
   padding: 20px;
   font-family: serif;


### PR DESCRIPTION
# Issue #124
Polished editor border and added box shadow

### Changes
- Polished editor border and box shadow
  - Removed the border radius attribute and reduced the width.
  - Added a drop show effect to the markdown editor 

- changed appearance of the markdown editor.
