### PR TITLE
test(SlateAsInputEditor): init unit tests for md output - I2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/accordproject/markdown-editor.git"
   },
   "scripts": {
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "dev": "webpack-dev-server --mode development --config webpack.config.js",
     "transpile": "babel src -d dist --copy-files",
     "prepublishOnly": "npm run transpile",
@@ -27,7 +27,15 @@
   "jest": {
     "transform": {
       "^.+\\.jsx?$": "babel-jest"
-    }
+    },
+    "moduleNameMapper": {
+      "\\.(css|less)$": "identity-obj-proxy"
+    },
+    "collectCoverageFrom": [
+      "src/SlateAsInputEditor/*.js",
+      "!**/node_modules/**",
+      "!**/travis/**"
+    ]
   },
   "keywords": [
     "accord",
@@ -56,6 +64,8 @@
     "@clausehq/eslint-config": "^0.1.8",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
+    "enzyme": "^3.10.0",
+    "enzyme-adapter-react-16": "^1.15.1",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.1",
     "eslint-config-loopback": "^13.1.0",

--- a/src/SlateAsInputEditor/index.test.js
+++ b/src/SlateAsInputEditor/index.test.js
@@ -1,0 +1,62 @@
+import React from "react";
+import Enzyme, { shallow } from "enzyme";
+import SlateAsInputEditor from "./index";
+import Adapter from "enzyme-adapter-react-16";
+
+import NoEdit from '../../src/plugins/noedit';
+import List from '../../src/plugins/list';
+import { SlateTransformer } from '@accordproject/markdown-slate';
+
+const plugins = [NoEdit(), List()];
+
+Enzyme.configure({adapter: new Adapter()});
+
+// Default markdown value
+let defaultValue = `My Heading
+
+This is text. This is *italic* text. This is **bold** text. This is a [link](https://clause.io). This is \`inline code\`.
+
+This is ***bold and italic*** text
+
+> This is a quote.
+
+Heading Two
+
+This is more text.
+
+Ordered lists:
+
+1. one
+2. two
+3. three
+
+Or:
+
+- apples
+- pears
+- peaches
+
+### Sub heading
+
+This is more text.
+
+Fin.`;
+
+const slateTransformer = new SlateTransformer();
+const propsObj = { width: '600px'};
+
+const onSlateValueChange = () => {
+    // A dummy onChange props
+  };
+
+describe("SlateAsInputEditor component", () => {
+    test("component mount", () => {
+        let slateValue = slateTransformer.fromMarkdown(defaultValue);
+        const markdown = slateTransformer.toMarkdown(slateValue);
+
+        expect(markdown).toEqual(defaultValue);
+
+        const wrapper = shallow(<SlateAsInputEditor readOnly={false} lockText={true} plugins={plugins} value={slateValue} onChange={onSlateValueChange} editorProps={propsObj} />);
+        expect(wrapper.find('.doc-inner').length).toBe(1);
+    });
+})

--- a/src/SlateAsInputEditor/index.test.js
+++ b/src/SlateAsInputEditor/index.test.js
@@ -52,11 +52,14 @@ const onSlateValueChange = () => {
 describe("SlateAsInputEditor component", () => {
     test("component mount", () => {
         let slateValue = slateTransformer.fromMarkdown(defaultValue);
-        const markdown = slateTransformer.toMarkdown(slateValue);
-
-        expect(markdown).toEqual(defaultValue);
-
         const wrapper = shallow(<SlateAsInputEditor readOnly={false} lockText={true} plugins={plugins} value={slateValue} onChange={onSlateValueChange} editorProps={propsObj} />);
         expect(wrapper.find('.doc-inner').length).toBe(1);
+    });
+
+    test("successful roundtrip", () => {
+        let slateValue = slateTransformer.fromMarkdown(defaultValue);
+        const markdown = slateTransformer.toMarkdown(slateValue);
+    
+        expect(markdown).toEqual(defaultValue);
     });
 })


### PR DESCRIPTION
# Issue https://github.com/accordproject/markdown-editor/issues/2
Added Unit tests for the round trip conversion from normal text to markdown.

### Changes
- Added Enzyme and Enzyme Adapter package
- Added test file with the default value and checking with expected and received.

Let me know if we need to add more tests.

![image](https://user-images.githubusercontent.com/13746289/67067709-fe92d400-f194-11e9-9322-e020703307b8.png)
