### PR TITLE
docs(*): update markdown files and fix typos - I257

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ Accord Project source code files are made available under the [Apache License, V
 
 Accord Project documentation files are made available under the [Creative Commons Attribution 4.0 International License][creativecommons] (CC-BY-4.0).
 
-[coc]: https://github.com/accordproject/docs/blob/master/Accord%20Project%20Code%20of%20Conduct.pdf
+[coc]: https://lfprojects.org/policies/code-of-conduct/
 [apslack]: https://accord-project-slack-signup.herokuapp.com
 
 [contribute.coc]: CONTRIBUTING.md#coc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to Markdown Editor
+# Contributing to Markdown-Editor
 
 > Thanks to the AngularJS team for the bulk of this text!
 
-We'd love for you to contribute to our source code and to make Markdown Editor even better than it is today! Here are the guidelines we'd like you to follow:
+We'd love for you to contribute to our source code and to make Markdown-Editor even better than it is today! Here are the guidelines we'd like you to follow:
 
 * [Code of Conduct][contribute.coc]
 * [Questions and Problems][contribute.question]
@@ -15,7 +15,7 @@ We'd love for you to contribute to our source code and to make Markdown Editor e
 
 ## <a name="coc"></a> Code of Conduct
 
-Help us keep Markdown Editor open and inclusive. Please read and follow our [Code of Conduct][coc].
+Help us keep Markdown-Editor open and inclusive. Please read and follow our [Code of Conduct][coc].
 
 ## <a name="requests"></a> Questions, Bugs, Features
 
@@ -43,7 +43,7 @@ If you would like to implement a new feature then consider what kind of change i
 
   as a Pull Request. See the section about [Pull Request Submission Guidelines][contribute.submitpr], and
 
-  for detailed information the [core development documentation][developers].
+  for detailed information read the [core development documentation][developers].
 
 ### <a name="docs"></a> Want a Doc Fix?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Markdown Editor
 
-> Thanks to the angularJS team for the bulk of this text!
+> Thanks to the AngularJS team for the bulk of this text!
 
 We'd love for you to contribute to our source code and to make Markdown Editor even better than it is today! Here are the guidelines we'd like you to follow:
 
@@ -25,13 +25,13 @@ Do not open issues for general support questions as we want to keep GitHub issue
 
 ### <a name="issue"></a> Found an Issue or Bug?
 
-If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository][github-issues]. Even better, you can submit a Pull Request with a fix.
+If you find a bug in the source code, you can help us by [submitting an issue][github-issues] to our GitHub Repository. Even better, you can submit a Pull Request with a fix.
 
 **Please see the **[**Submission Guidelines**][contribute.submit]** below.**
 
 ### <a name="feature"></a> Missing a Feature?
 
-You can request a new feature by submitting an issue to our [GitHub Repository][github-issues].
+You can request a new feature by submitting an issue to our [GitHub Repository][github].
 
 If you would like to implement a new feature then consider what kind of change it is:
 
@@ -70,7 +70,7 @@ The "[new issue][github-new-issue]" form contains a number of prompts that you s
 Before you submit your pull request consider the following guidelines:
 
 * Ensure there is an open [Issue][github-issues] for what you will be working on. If there is not, open one up by going through [these guidelines][contribute.submit].
-* Search [GitHub][pulls] for an open or closed Pull Request that relates to your submission. You don't want to duplicate effort.
+* Search for an open or closed [Pull Request][pulls] that relates to your submission. You don't want to duplicate effort.
 * Create the [development environment][developers.setup]
 * Make your changes in a new git branch:
 
@@ -88,7 +88,7 @@ Before you submit your pull request consider the following guidelines:
 * Follow our [Coding Rules][developers.rules].
 * Ensure you provide a DCO sign-off for your commits using the -s option of git commit. For more information see [how this works][dcohow].
 * If the changes affect public APIs, change or add relevant [documentation][developers.documentation].
-* Run the [unit][developers.unit-tests] test suite, and ensure that all tests pass.
+* Run the [unit test suite][developers.unit-tests], and ensure that all tests pass.
 
 * Commit your changes using a descriptive commit message that follows our [commit message conventions][developers.commits]. Adherence to the [commit message conventions][developers.commits] is required, because release notes are automatically generated from these messages.
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,4 +1,4 @@
-# Developing Cicero-UI
+# Developing Markdown-Editor
 
 * [Development Setup][developers.setup]
 * [Coding Rules][developers.rules]
@@ -7,12 +7,12 @@
 
 ## <a name="setup"> Development Setup
 
-This document describes how to set up your development environment to build and test Cicero-UI, and
+This document describes how to set up your development environment to build and test Markdown-Editor, and
 explains the basic mechanics of using `git`, `node`, `npm`.
 
 ### Installing Dependencies
 
-Before you can build Cicero-UI, you must install and configure the following dependencies on your
+Before you can build Markdown-Editor, you must install and configure the following dependencies on your
 machine:
 
 * [Git][git]: The [Github Guide to Installing Git][git-setup] is a good source of information.
@@ -24,27 +24,27 @@ machine:
   We recommend using [nvm][nvm] (or [nvm-windows][nvm-windows])
   to manage and install Node.js, which makes it easy to change the version of Node.js per project.
 
-### Forking Markdown Editor on Github
+### Forking Markdown-Editor on Github
 
-To contribute code to Markdown Editor, you must have a GitHub account so you can push code to your own
-fork of Markdown Editor and open Pull Requests in the [GitHub Repository][github].
+To contribute code to Markdown-Editor, you must have a GitHub account so you can push code to your own
+fork of Markdown-Editor and open Pull Requests in the [GitHub Repository][github].
 
 To create a Github account, follow the instructions [here][github-signup].
 Afterwards, go ahead and [fork][github-forking] the
-[main Markdown Editor repository][github].
+[main Markdown-Editor repository][github].
 
-### Building Markdown Editor
+### Building Markdown-Editor
 
-To build Markdown Editor, you clone the source code repository and use lerna to build:
+To build Markdown-Editor, you clone the source code repository and use lerna to build:
 
 ```shell
 # Clone your Github repository:
 git clone https://github.com/<github username>/markdown-editor.git
 
-# Go to the Markdown Editor directory:
+# Go to the Markdown-Editor directory:
 cd markdown-editor
 
-# Add the main Markdown Editor repository as an upstream remote to your repository:
+# Add the main Markdown-Editor repository as an upstream remote to your repository:
 git remote add upstream "https://github.com/acccordproject/markdown-editor.git"
 
 # Install node.js dependencies:
@@ -85,7 +85,7 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 
 We have very precise rules over how our git commit messages can be formatted.  This leads to **more
 readable messages** that are easy to follow when looking through the **project history** and **git logs**.  
-But also, we use the git commit messages to **generate the Markdown Editor change log**.
+But also, we use the git commit messages to **generate the Markdown-Editor change log**.
 
 The commit message formatting can be added using a version of typical git workflow.
 
@@ -132,7 +132,7 @@ The subject contains succinct description of the change:
 * no dot (.) at the end
 
 ### Footer
-The footer should contain [reference GitHub Issues that this commit addresses][github-issues].
+The footer should contain [reference GitHub Issues][github-issues] that this commit addresses.
 
 ## <a name="pullrequests"></a> GitHub Pull Request Guidelines
 Pull Requests should consist of a complete addition to the code which contains value. 
@@ -164,14 +164,14 @@ When approved and ready to merge, a Pull Request should be squashed down to a si
 
 ## <a name="documentation"></a> Writing Documentation
 
-The Markdown Editor project uses [jsdoc][jsdoc] for all of its code
+The Markdown-Editor project uses [jsdoc][jsdoc] for all of its code
 documentation.
 
 This means that all the docs are stored inline in the source code and so are kept in sync as it
 changes.
 
 This means that since we generate the documentation from the source code, we can easily provide
-version-specific documentation by simply checking out a version of Markdown Editor and running the build.
+version-specific documentation by simply checking out a version of Markdown-Editor and running the build.
 
 ## License <a name="license"></a>
 

--- a/README.md
+++ b/README.md
@@ -193,5 +193,5 @@ Accord Project documentation files are made available under the [Creative Common
 [contributing]: https://github.com/accordproject/markdown-editor/blob/master/CONTRIBUTING.md
 [developers]: https://github.com/accordproject/markdown-editor/blob/master/DEVELOPERS.md
 
-[apache]: https://github.com/accordproject/template-studio-v2/blob/master/LICENSE
+[apache]: https://github.com/accordproject/markdown-editor/blob/master/LICENSE
 [creativecommons]: http://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Signed-off-by: Michael Zhou <myz227@nyu.edu>

<OVERALL SUMMARY OF PULL REQUEST>
Updated markdown files by correcting for incorrect markdown links, integrating existing links into new markdown, and ensuring consistency in markdown style. Also fixes typos, grammar, and punctuation errors in documentation. All tests confirmed to pass.

### Changes
- Modified markdown to be more appropriate with content of associated links
- Fixed typos and miscellaneous errors in punctuation and grammar

### Related Issues
- [Cicero Template Library Issue 257](https://github.com/accordproject/cicero-template-library/issues/257)
- Pull Request [#280](https://github.com/accordproject/cicero-template-library/pull/280)