### PR TITLE
Add option to hide markdown pane

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import {
-  Divider, Grid, Segment
+  Button, Divider, Grid, Segment
 } from 'semantic-ui-react';
 
 import ReactDOM from 'react-dom';
@@ -61,6 +61,7 @@ function Demo() {
    */
   const [slateValue, setSlateValue] = useState(slateTransformer.fromMarkdown(defaultMarkdown));
   const [markdown, setMarkdown] = useState(defaultMarkdown);
+  const [displayMarkdownPane, setDisplayMarkdownPane] = useState(true);
 
   /**
    * Called when the markdown changes
@@ -80,20 +81,33 @@ function Demo() {
   }, []);
 
   return (
-    <div>
+    <>
+      <Button onClick={() => setDisplayMarkdownPane(!displayMarkdownPane)}>TOGGLE MD DISPLAY</Button>
       <Segment>
-    <Grid columns={2}>
-      <Grid.Column>
-        <MarkdownAsInputEditor readOnly={true} plugins={plugins} markdown={markdown} onChange={onMarkdownChange}/>
-      </Grid.Column>
-
-      <Grid.Column>
-        <SlateAsInputEditor readOnly={false} lockText={true} plugins={plugins} value={slateValue} onChange={onSlateValueChange} editorProps={propsObj} />
-      </Grid.Column>
-    </Grid>
-    <Divider vertical>Preview</Divider>
-  </Segment>
-    </div>
+        <Grid columns={2}>
+          <Grid.Column>
+            <MarkdownAsInputEditor
+              readOnly={true}
+              plugins={plugins}
+              markdown={markdown}
+              onChange={onMarkdownChange}
+              display={displayMarkdownPane}
+            />
+          </Grid.Column>
+          <Grid.Column>
+            <SlateAsInputEditor
+              readOnly={false}
+              lockText={true}
+              plugins={plugins}
+              value={slateValue}
+              onChange={onSlateValueChange}
+              editorProps={propsObj}
+            />
+          </Grid.Column>
+        </Grid>
+        <Divider vertical>Preview</Divider>
+      </Segment>
+    </>
   );
 }
 

--- a/src/MarkdownAsInputEditor/index.js
+++ b/src/MarkdownAsInputEditor/index.js
@@ -32,7 +32,8 @@ function MarkdownAsInputEditor(props) {
    * Destructure props for efficiency
    */
   const {
-    onChange
+    onChange,
+    display
   } = props;
 
   const onChangeHandler = (evt) => {
@@ -42,26 +43,23 @@ function MarkdownAsInputEditor(props) {
   /**
    * Render the component, based on showSlate
    */
-  const card = <Card fluid>
-  <Card.Content>
-  <TextareaAutosize
-    className={'textarea'}
-    width={'100%'}
-    placeholder={props.markdown}
-    value={props.markdown}
-    // eslint-disable-next-line no-unused-vars
-    onChange={onChangeHandler}
-    readOnly={props.readOnly}
-  />
-  </Card.Content>
-</Card>;
+  const card = (
+    <Card fluid>
+      <Card.Content>
+        <TextareaAutosize
+          className={'textarea'}
+          width={'100%'}
+          placeholder={props.markdown}
+          value={props.markdown}
+          onChange={onChangeHandler}
+          readOnly={props.readOnly}
+        />
+      </Card.Content>
+    </Card>
+  );
 
   return (
-    <div>
-      <Card.Group>
-        {card}
-      </Card.Group>
-    </div>
+    display && <Card.Group>{card}</Card.Group>
   );
 }
 
@@ -83,6 +81,11 @@ MarkdownAsInputEditor.propTypes = {
    * Boolean to make editor read-only (uneditable) or not (editable)
    */
   readOnly: PropTypes.bool,
+
+  /**
+   * Boolean to display editor or not
+   */
+  display: PropTypes.bool
 };
 
 /**
@@ -91,6 +94,7 @@ MarkdownAsInputEditor.propTypes = {
 MarkdownAsInputEditor.defaultProps = {
   value: 'Welcome! Edit this text to begin.',
   readOnly: false,
+  display: true
 };
 
 export default MarkdownAsInputEditor;


### PR DESCRIPTION
Signed-off-by: J <johnnyqbui7@gmail.com>

# Issue #23 
Add option to toggle display of markdown editor.

### Changes
- Add `display` prop to `MarkdownAsInputEditor`
  - add `display PropTypes`
- Cleaned up code
- Add `display` prop which takes a boolean to toggle display of markdown editor.

### Flags
- <DESCRIBE ISSUES OR HOLDS FOR REVIEWERS>

### Related Issues
- Issue #79 
- Issue #112 
