### PR TITLE
feat(*): allow styling for shadow and border - I124

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ This is an object with the following possible css inputs as strings:
 - `BUTTON_SYMBOL_ACTIVE`
 - `DROPDOWN_COLOR`
 - `TOOLBAR_BACKGROUND`
+- `EDITOR_BORDER_RADIUS`
 - `EDITOR_SHADOW`
 - `EDITOR_BORDER`
 - `TOOLTIP_BACKGROUND`

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ This is an object with the following possible css inputs as strings:
 - `BUTTON_SYMBOL_ACTIVE`
 - `DROPDOWN_COLOR`
 - `TOOLBAR_BACKGROUND`
+- `EDITOR_SHADOW`
+- `EDITOR_BORDER`
 - `TOOLTIP_BACKGROUND`
 - `TOOLTIP`
 - `TOOLBAR_SHADOW`

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -37,7 +37,7 @@ const EditorWrapper = styled.div`
   max-width: ${props => props.width || 'none'};
   min-width: ${props => props.width || 'none'};
   border: 1px solid #979797;
-  border-radius: 10px;
+  box-shadow: 1px 2px 4px rgba(0, 0, 0, .5);
   margin: 50px auto;
   padding: 20px;
   font-family: serif;

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -36,6 +36,7 @@ const EditorWrapper = styled.div`
   min-height: 750px;
   max-width: ${props => props.width || 'none'};
   min-width: ${props => props.width || 'none'};
+  border-radius: ${props => props.EDITOR_BORDER-RADIUS || ' 10px'};
   border: ${props => props.EDITOR_BORDER || ' 1px solid #979797'};
   box-shadow: ${props => props.EDITOR_SHADOW || ' 1px 2px 4px rgba(0, 0, 0, .5)'};
   margin: 50px auto;
@@ -471,6 +472,7 @@ SlateAsInputEditor.propTypes = {
     BUTTON_SYMBOL_ACTIVE: PropTypes.string,
     DROPDOWN_COLOR: PropTypes.string,
     EDITOR_BORDER:PropTypes.string,
+    EDITOR_BORDER_RADIUS:PropTypes.string,
     EDITOR_SHADOW:PropTypes.string,
     TOOLBAR_BACKGROUND: PropTypes.string,
     TOOLTIP_BACKGROUND: PropTypes.string,

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -36,8 +36,8 @@ const EditorWrapper = styled.div`
   min-height: 750px;
   max-width: ${props => props.width || 'none'};
   min-width: ${props => props.width || 'none'};
-  border: 1px solid #979797;
-  box-shadow: 1px 2px 4px rgba(0, 0, 0, .5);
+  border: ${props => props.EDITOR_BORDER || ' 1px solid #979797'};
+  box-shadow: ${props => props.EDITOR_SHADOW || ' 1px 2px 4px rgba(0, 0, 0, .5)'};
   margin: 50px auto;
   padding: 20px;
   font-family: serif;
@@ -470,6 +470,8 @@ SlateAsInputEditor.propTypes = {
     BUTTON_SYMBOL_INACTIVE: PropTypes.string,
     BUTTON_SYMBOL_ACTIVE: PropTypes.string,
     DROPDOWN_COLOR: PropTypes.string,
+    EDITOR_BORDER:PropTypes.string,
+    EDITOR_SHADOW:PropTypes.string,
     TOOLBAR_BACKGROUND: PropTypes.string,
     TOOLTIP_BACKGROUND: PropTypes.string,
     TOOLTIP: PropTypes.string,

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -36,7 +36,7 @@ const EditorWrapper = styled.div`
   min-height: 750px;
   max-width: ${props => props.width || 'none'};
   min-width: ${props => props.width || 'none'};
-  border-radius: ${props => props.EDITOR_BORDER-RADIUS || ' 10px'};
+  border-radius: ${props => props.EDITOR_BORDER_RADIUS || ' 10px'};
   border: ${props => props.EDITOR_BORDER || ' 1px solid #979797'};
   box-shadow: ${props => props.EDITOR_SHADOW || ' 1px 2px 4px rgba(0, 0, 0, .5)'};
   margin: 50px auto;


### PR DESCRIPTION
# Issue #124 
<OVERALL SUMMARY OF PULL REQUEST>
Added additional props for Shadow and border attributes

### Changes
-  Added props for code flexibility
  - Additional props for Border and Box-Shadow attributes of Markdown Editor
- Changed src/SlateAsInputEditor/index.js

### Flags
- <DESCRIBE ISSUES OR HOLDS FOR REVIEWERS>

### Related Issues
- Issue #<NUMBER HERE>
- Pull Request #<NUMBER HERE>