### PR TITLE
fix(SlateAsInputEditor): fix escaping out of list

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -369,9 +369,19 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
     const { startBlock } = value;
     if (end.offset !== startBlock.text.length) return next();
 
+    // Hitting enter on a blank list item will break out of the enclosing list
+    if (startBlock.type === 'list_item' && startBlock.text.length === 0) {
+      editor.withoutNormalizing(() => {
+        event.preventDefault();
+        editor
+          .setBlocks('paragraph')
+          .unwrapBlock('ol_list')
+          .unwrapBlock('ul_list');
+      });
+      return false;
     // if you hit enter inside anything that is not a heading
     // we use the default behavior
-    if (!startBlock.type.startsWith('heading')) {
+    } else if (!startBlock.type.startsWith('heading')) {
       return next();
     }
 


### PR DESCRIPTION
# Issue #127
These changes address the ability to escape out of either ordered or unordered list blocks back into a standard paragraph block when <kbd>ENTER</kbd> is pressed on a blank list item.

### Changes
- Modifies the <kbd>ENTER</kbd> key handler to support the behaviour described above

### Flags
Looks like the test infrastructure is in flux so I haven't added any integration tests to capture the new behaviour.

