### PR TITLE
fix(FormattingToolbar): toolbar buttons work in locktext mode

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -110,9 +110,13 @@ export default class FormatToolbar extends React.Component {
    * When a mark button is clicked, toggle the current mark.
    */
   onClickMark(event, type) {
-    const { editor } = this.props;
-    event.preventDefault();
-    editor.toggleMark(type);
+    const { editor, pluginManager } = this.props;
+    const { value } = editor;
+
+    if(pluginManager.isEditable(editor.value,type)) {
+      event.preventDefault();
+      editor.toggleMark(type);      
+    }
   }
 
   /**

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -110,10 +110,10 @@ export default class FormatToolbar extends React.Component {
    * When a mark button is clicked, toggle the current mark.
    */
   onClickMark(event, type) {
-    const { editor, pluginManager } = this.props;
+    const { editor, pluginManager, lockText } = this.props;
     const { value } = editor;
 
-    if(pluginManager.isEditable(editor.value,type)) {
+    if (!lockText || pluginManager.isEditable(value, type)) {
       event.preventDefault();
       editor.toggleMark(type);      
     }

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -458,6 +458,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
           editor={editor}
           pluginManager={pluginManager}
           editorProps={editorProps}
+          lockText={props.lockText}
         />
         {children}
       </div>


### PR DESCRIPTION

# Issue #122 
Currently, formatting tools such as Bold, Italic is working although lockText is true.

### Changes
Added checking on Editable before calling toggleMark

