### PR TITLE
style(SlateAsInputEditor): Makes editor take full height of the content area

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -40,7 +40,6 @@ const EditorWrapper = styled.div`
   border: ${props => props.EDITOR_BORDER || ' 1px solid #979797'};
   box-shadow: ${props => props.EDITOR_SHADOW || ' 1px 2px 4px rgba(0, 0, 0, .5)'};
   margin: 50px auto;
-  padding: 20px;
   font-family: serif;
   font-style: normal;
   font-weight: normal;
@@ -52,6 +51,17 @@ const EditorWrapper = styled.div`
   text-transform: none;
   text-align: left;
   text-indent: 0ex;
+  display:flex;
+
+  > div {
+    width: 100%;
+  }
+
+  .doc-inner {
+    width: 100%;
+    height: 100%;
+    padding: 20px;
+  }
 `;
 
 const ToolbarWrapper = styled.div`


### PR DESCRIPTION
Signed-off-by: husseyexplores <husseyexplores@gmail.com>

# Issue #154 
<OVERALL SUMMARY OF PULL REQUEST>

### Changes
- Makes the rich text editor take the full height of the available area so if the content is less than the min-height (`750px`), clicking on whitespace takes the cursor to the very end.

### Flags
One thing to note that is, currently, if the editor is blurred and you focus back on the editor (by clicking anywhere in the editable area) the cursor gets placed on the very start, but on where the click has happened. 
The fix is to define a `onFocus` function on `Editor` component. I already implemented the fix in this PR: #159 as I found out the issue and the respective fix during working on that PR. 
If you think that it should be a separate issue/PR for issue tracking purposes, please let me know.

### Related Issues
\-