### PR TITLE
test(FormattingToolbar): init tests for buttons

### DIFF
--- a/src/FormattingToolbar/index.test.js
+++ b/src/FormattingToolbar/index.test.js
@@ -1,0 +1,43 @@
+import React from "react";
+import Enzyme, { mount } from "enzyme";
+import FormatToolbar from "./index";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+
+describe("SlateAsInputEditor component", () => {
+    test("a11y test", () => {
+        const toolbarWrapper = document.createElement("div");
+        toolbarWrapper.id = "slate-toolbar-wrapper-id";
+        window.document.querySelector = jest.fn(() => toolbarWrapper);
+
+        const editor = {
+            value: {
+                activeMarks: [],
+                blocks: [],
+                fragment: {
+                    text: ""
+                },
+                inlines: []
+            }
+        };
+        const pluginManager = {
+            renderToolbar: () => null
+        };
+        const props = { editor, editorProps: {}, pluginManager };
+        const wrapper = mount(
+            <FormatToolbar {...props} />
+        );
+        expect(wrapper.find("svg").map(svg => svg.props()["aria-label"]))
+            .toEqual([
+                "bold",
+                "italic",
+                "code",
+                "block_quote",
+                "ul_list",
+                "ol_list",
+                "link",
+                "undo",
+                "redo",
+            ]);
+    });
+});


### PR DESCRIPTION
In this commit, I found that action had the correct aria text we
wanted, instead of type.

I wrote a jest test to prove that all the svg icons have unique aria
labels.

I tried running eslint, but it seems not to work for me.  I can
try to fix it, but I think that should be a separate task.

# Issue #<NUMBER HERE>
<OVERALL SUMMARY OF PULL REQUEST>

### Changes
- <INSERT DESCRIPTION OF CHANGES>
  - <SUB NOTES OF DESCRIPTIONS>
- <SUMMARIZE ALL COMMITS IN PULL REQUEST>

### Flags
- <DESCRIBE ISSUES OR HOLDS FOR REVIEWERS>

### Related Issues
- Issue #<NUMBER HERE>
- Pull Request #<NUMBER HERE>