### PR TITLE
fix: First Keypress in lockText Mode Executes bug fix

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -442,6 +442,13 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
     onChange(value);
   };
 
+  /**
+   * Render the annotations which are added/updated for the editor
+   */
+  const renderAnnotation = useCallback((props, editor, next) => {
+    return next();
+  });
+
   return (
     <div>
       <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" />
@@ -459,6 +466,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
           onKeyDown={onKeyDown}
           onPaste={onPaste}
           renderBlock={renderBlock}
+          renderAnnotation={renderAnnotation}
           renderInline={renderInline}
           renderMark={renderMark}
           editorProps={editorProps}


### PR DESCRIPTION
# Issue #123 
This PR fixes the bug wherein the first keypress in lockText mode was executing.

### Changes
- added `renderAnnotation` callback hook
  - this renders any annotations which are added/updated via useEffect hook (here for lockText annotation)

### Flags
- none

### Related Issues
- Issue #132 