### PR TITLE
fix(SlateAsInputEditor): Make Editor Unobtrusive - I175

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -32,7 +32,7 @@ import '../styles.css';
 
 const EditorWrapper = styled.div`
   background: #fff;
-  min-height: 750px;
+  height: 750px;
   max-width: ${props => props.WIDTH || 'none'};
   min-width: ${props => props.WIDTH || 'none'};
   border-radius: ${props => props.EDITOR_BORDER_RADIUS || ' 10px'};
@@ -51,6 +51,7 @@ const EditorWrapper = styled.div`
   text-align: left;
   text-indent: 0ex;
   display:flex;
+  overflow-y: scroll;
 
   > div {
     width: 100%;


### PR DESCRIPTION
Add a fixed height and a scroll behaviour on overflow.

Signed-off-by: V1shvesh <22243137+V1shvesh@users.noreply.github.com>

# Issue #175 
This PR solves the issue of the Editor Scrollbar barging on top of the Toolbar by modifying the styles of EditorWrapper.

### Related Issues
- Issue #175