### PR TITLE
fix(FormattingToolbar): use editor.findDOMRange instead of importing it

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import {
   Button, Dropdown, Form, Input, Popup, Ref
 } from 'semantic-ui-react';
-import { findDOMRange } from 'slate-react';
 
 import * as action from './toolbarMethods';
 import * as styles from './toolbarStyles';
@@ -373,7 +372,7 @@ export default class FormatToolbar extends React.Component {
     }
 
     // Get selection node from slate
-    const selection = findDOMRange(this.props.editor.value.selection);
+    const selection = this.props.editor.findDOMRange(this.props.editor.value.selection);
 
     popupPosition = 'bottom left';
 

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -50,7 +50,7 @@ const EditorWrapper = styled.div`
   text-transform: none;
   text-align: left;
   text-indent: 0ex;
-  display:flex;
+  display: flex;
 
   > div {
     width: 100%;


### PR DESCRIPTION
fix(FormattingToolbar): use editor.findDOMRange instead of importing it
Signed-off-by: Diana Lease <dianarlease@gmail.com>

Fixes this warning:
![Screen Shot 2019-11-05 at 3 17 11 PM](https://user-images.githubusercontent.com/20543103/68242920-6ba0c900-ffdf-11e9-888c-63f3a41d99f6.png)
