### PR TITLE
fix(SlateAsInputEditor): always pass List and NoEdit plugins to editor

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -27,6 +27,8 @@ import baseSchema from '../schema';
 import PluginManager from '../PluginManager';
 import { FromHTML } from '../html/fromHTML';
 import FormatToolbar from '../FormattingToolbar';
+import NoEditPlugin from '../plugins/noedit';
+import ListPlugin from '../plugins/list';
 
 import '../styles.css';
 
@@ -448,6 +450,12 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
     setTimeout(editor.focus, 0);
   };
 
+  const allPlugins = React.useMemo(() => (props.plugins
+    ? props.plugins.concat(
+      [ListPlugin(), NoEditPlugin()]
+    )
+    : [ListPlugin(), NoEditPlugin()]), [props.plugins]);
+
   return (
     <div>
       <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" />
@@ -461,7 +469,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
           onChange={onChangeHandler}
           onFocus={onFocusHandler}
           schema={slateSchema}
-          plugins={props.plugins}
+          plugins={allPlugins}
           onBeforeInput={onBeforeInput}
           onKeyDown={onKeyDown}
           onPaste={onPaste}


### PR DESCRIPTION
fix(SlateAsInputEditor): always pass List and NoEdit plugins to editor
Signed-off-by: Diana Lease <dianarlease@gmail.com>

# Issue https://github.com/accordproject/cicero-ui/issues/213