### PR TITLE
fix(SlateAsInputEditor): disallow paste if in non-editable text

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -403,6 +403,10 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
   * @return {*} the react component
   */
   const onPaste = (event, editor, next) => {
+    if (!isEditable(editor, 'paste')) {
+      event.preventDefault();
+      return false;
+    }
     if (isEditable(editor, 'paste')) {
       const transfer = getEventTransfer(event);
       if (transfer.type === 'html') {


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

# Issue #132 
fix(SlateAsInputEditor): disallow paste if in non-editable text
