### PR TITLE
feat(SlateAsInputEditor): add ability to pass onUndoOrRedo handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/markdown-editor",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7179,8 +7179,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7201,14 +7200,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7223,20 +7220,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7353,8 +7347,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7366,7 +7359,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7381,7 +7373,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7389,14 +7380,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7415,7 +7404,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7496,8 +7484,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7509,7 +7496,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7595,8 +7581,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7632,7 +7617,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7652,7 +7636,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7696,14 +7679,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8695,10 +8676,9 @@
       }
     },
     "is-hotkey": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.4.tgz",
-      "integrity": "sha512-Py+aW4r5mBBY18TGzGz286/gKS+fCQ0Hee3qkaiSmEPiD0PqFpe0wuA3l7rTOUKyeXl8Mxf3XzJxIoTlSv+kxA==",
-      "dev": true
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.6.tgz",
+      "integrity": "sha512-1+hMr0GLPM0M49UDRt9RgE8i+SM29UY4AGRP6sGz6fThOVXqSrEvTMakolhHMcVizJnPNAoMpEmE+Oi1k2NrZQ=="
     },
     "is-in-browser": {
       "version": "1.1.3",
@@ -14535,6 +14515,14 @@
       "requires": {
         "is-hotkey": "0.1.4",
         "slate-dev-environment": "^0.2.2"
+      },
+      "dependencies": {
+        "is-hotkey": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.4.tgz",
+          "integrity": "sha512-Py+aW4r5mBBY18TGzGz286/gKS+fCQ0Hee3qkaiSmEPiD0PqFpe0wuA3l7rTOUKyeXl8Mxf3XzJxIoTlSv+kxA==",
+          "dev": true
+        }
       }
     },
     "slate-html-serializer": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@accordproject/markdown-slate": "^0.9.0",
     "css-loader": "^3.2.0",
     "immutable": "^3.8.2",
+    "is-hotkey": "^0.1.6",
     "prop-types": "^15.7.2",
     "react-immutable-proptypes": "^2.1.0",
     "react-textarea-autosize": "^7.1.2",

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -164,10 +164,11 @@ export default class FormatToolbar extends React.Component {
   /**
    * When a mark button is clicked, toggle undo or redo.
    */
-  onClickHistory(event, action) {
+  async onClickHistory(event, action) {
     const { editor } = this.props;
     event.preventDefault();
-    ((action === 'undo') ? editor.undo() : editor.redo());
+    ((action === 'undo') ? await editor.undo() : await editor.redo());
+    if (editor.props.editorProps.onUndoOrRedo) editor.props.editorProps.onUndoOrRedo(editor);
   }
 
   /**

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -23,6 +23,8 @@ import { Editor, getEventTransfer } from 'slate-react';
 import { Value } from 'slate';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import isHotKey from 'is-hotkey';
+
 import baseSchema from '../schema';
 import PluginManager from '../PluginManager';
 import { FromHTML } from '../html/fromHTML';
@@ -333,7 +335,19 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
   * @param {*} editor
   * @param {*} next
   */
-  const onKeyDown = (event, editor, next) => {
+  const onKeyDown = async (event, editor, next) => {
+    if (isHotKey('mod+z', event)) {
+      if (editor.props.editorProps.onUndoOrRedo) {
+        await editor.undo();
+        return editor.props.editorProps.onUndoOrRedo(editor);
+      }
+    }
+    if (isHotKey('mod+shift+z', event)) {
+      if (editor.props.editorProps.onUndoOrRedo) {
+        await editor.redo();
+        return editor.props.editorProps.onUndoOrRedo(editor);
+      }
+    }
     switch (event.key) {
       case 'Enter':
         return handleEnter(event, editor, next);


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

feat(SlateAsInputEditor): add ability to pass onUndoOrRedo handler

- There is no way to access Slate's undo event directly, so I call the handler when a user uses the keyboard shortcut to undo/redo or clicks the icon in the toolbar. Refer to convo from Slate slack [here](https://slate-js.slack.com/archives/C1RH7AXSS/p1575921321010400).