### PR TITLE
fix(FormattingToolbar): pass hyperlink type to link button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/markdown-editor",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,12 +38,12 @@
       }
     },
     "@accordproject/markdown-cicero": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.9.2.tgz",
-      "integrity": "sha512-/GSWyRoLO9rMZ6En0JUgPkeUT0AS9+GL4bm18Qs6ne+W/zJbSZK9EuAKADNhXEQf7dhKZ/i6j4RGQ3HqagzhSQ==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.9.4.tgz",
+      "integrity": "sha512-R7XReA19gXGmHcKwKd40CB6Ggd8Ono7cb1mycrNGXdRPkbBvhkEtRir3WmagMacLancc3YdgazRzXhIk7izcNQ==",
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
-        "@accordproject/markdown-common": "0.9.2",
+        "@accordproject/markdown-common": "0.9.4",
         "commonmark": "^0.29.0",
         "jsome": "2.5.0",
         "sax": "^1.2.4",
@@ -52,9 +52,9 @@
       }
     },
     "@accordproject/markdown-common": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.9.2.tgz",
-      "integrity": "sha512-soAOT8eZgFePDjv4a/mpJYDiqlD/qpq611qRCkQLByTSUfdA8jpypzoHiV+1arO/2P5Nt0EGqtsv/aowNTZ2HA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.9.4.tgz",
+      "integrity": "sha512-NUSMBI0NjjRhBX+6uQjnkkTpQgtIP6GyYvVxazF2rdXb232a5JNlmMG0Qxf7LBC+DeAGB2Dxch5tzdVdWAoEeg==",
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
         "commonmark": "^0.29.0",
@@ -65,12 +65,12 @@
       }
     },
     "@accordproject/markdown-html": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.9.2.tgz",
-      "integrity": "sha512-aOHwRtqAev4bTxThMCJNvxtxcA+cHkjyIxV7eeFiW6ak+lIG9wKiF4d2yORkqf9nZY6QLXZe51p5ALRFUIDtGw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.9.4.tgz",
+      "integrity": "sha512-pUyPHKRZNUruzYvuqCCzIVnLpl3Fb+PwhduJCD4tg+KFL2pjuqLy4IremOeVYt0XPR8ykAJqXr6gZ5uHU7+JFg==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.9.2",
-        "@accordproject/markdown-common": "0.9.2",
+        "@accordproject/markdown-cicero": "0.9.4",
+        "@accordproject/markdown-common": "0.9.4",
         "jsdom": "^15.2.1",
         "type-of": "^2.0.1"
       },
@@ -164,21 +164,18 @@
           }
         },
         "ws": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-          "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-          "requires": {
-            "async-limiter": "^1.0.0"
-          }
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+          "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
         }
       }
     },
     "@accordproject/markdown-slate": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.9.2.tgz",
-      "integrity": "sha512-Ng90kJPUhJwHCn0BapkXcK/1b3gDVTch6Lm6mb+x557ubCSBLEufAHdqq8xgUuyVKOllAjELNXwM1WoDO4Ssvw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.9.4.tgz",
+      "integrity": "sha512-oQnEg17dz4lum76MmiLw3Iz1jMywdjq/OHeMijWLbDRWLs07eSKuynRkkH5wbLbC3S/VTs+EnhrMnfRy+m5cDA==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.9.2"
+        "@accordproject/markdown-cicero": "0.9.4"
       }
     },
     "@babel/cli": {
@@ -3257,7 +3254,8 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -7257,7 +7255,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7278,12 +7277,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7298,17 +7299,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7425,7 +7429,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7437,6 +7442,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7451,6 +7457,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7458,12 +7465,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7482,6 +7491,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7562,7 +7572,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7574,6 +7585,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7659,7 +7671,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7695,6 +7708,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7714,6 +7728,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7757,12 +7772,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -100,8 +100,8 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@accordproject/markdown-slate": "^0.9.2",
-    "@accordproject/markdown-html": "^0.9.2",
+    "@accordproject/markdown-slate": "^0.9.4",
+    "@accordproject/markdown-html": "^0.9.4",
     "css-loader": "^3.2.0",
     "immutable": "^3.8.2",
     "is-hotkey": "^0.1.6",

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -189,7 +189,7 @@ export default class FormatToolbar extends React.Component {
    */
   onClickLinkButton() {
     const { editor, pluginManager, lockText } = this.props;
-    if (!lockText || pluginManager.isEditable(editor)) {
+    if (!lockText || pluginManager.isEditable(editor, 'hyperlink')) {
       const hasLinksBool = action.hasLinks(editor);
       const isOnlyLinkBool = action.isOnlyLink(editor);
       if (hasLinksBool && !isOnlyLinkBool) return;


### PR DESCRIPTION
# No Issue

### Changes
- Pass a `'hyperlink'` type into `isEditable` for link button

### Flags
- N/A

### Related Issues
- [Cicero-UI #257](https://github.com/accordproject/cicero-ui/pull/257)