### PR TITLE
[WIP] feat(SlateAsInputEditor): adds id to headings to be used as anchors

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -171,24 +171,25 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
    * Renders a block
    */
   // @ts-ignore
-  const renderBlock = useCallback((props, editor, next) => {
-    const { node, attributes, children } = props;
+  const renderBlock = useCallback((blockProps, editor, next) => {
+    const { node, attributes, children } = blockProps;
+    const anchorName = encodeURIComponent(`${node.text}-${node.key}`);
 
     switch (node.type) {
       case 'paragraph':
         return <p {...attributes}>{children}</p>;
       case 'heading_one':
-        return <Heading as="h1" {...attributes}>{children}</Heading>;
+        return <Heading as="h1" {...attributes} id={anchorName}>{children}</Heading>;
       case 'heading_two':
-        return <Heading as="h2" {...attributes}>{children}</Heading>;
+        return <Heading as="h2" {...attributes} id={anchorName}>{children}</Heading>;
       case 'heading_three':
-        return <Heading as="h3" {...attributes}>{children}</Heading>;
+        return <Heading as="h3" {...attributes} id={anchorName}>{children}</Heading>;
       case 'heading_four':
-        return <Heading as="h4" {...attributes}>{children}</Heading>;
+        return <Heading as="h4" {...attributes} id={anchorName}>{children}</Heading>;
       case 'heading_five':
-        return <Heading as="h5" {...attributes}>{children}</Heading>;
+        return <Heading as="h5" {...attributes} id={anchorName}>{children}</Heading>;
       case 'heading_six':
-        return <Heading as="h6" {...attributes}>{children}</Heading>;
+        return <Heading as="h6" {...attributes} id={anchorName}>{children}</Heading>;
       case 'horizontal_rule':
         return <hr {...attributes} />;
       case 'block_quote':


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

### Issue 
- As the editor stands today, there is no way to link to a specific place on the document

### Changes
- Adds an `id` property to headings which is a combination of the text and key
- This will allow us to link to a specific headings on the web page like so `http://localhost:3001/examples#Heading%20Two-35`

### Flags
- Because of the toolbar, the heading the page jumps to actually gets hidden
- I have not tested how this will work when the editor is imported into another app where it has a fixed height and its own scrollbar.
- Because the "key" property can change, it's possibly if the document is edited, the key of a heading could change and therefore the link would no longer point to that heading.
- Right now to create the link, you'd have to inspect the element and get the `id`. We should have an icon or something similar to what github does that the user can click and then get the link from the browser's url field. In the screenshot from github below, the link icon appears on hover. (cc @Michael-Grover)
![Screen Shot 2020-01-31 at 10 22 59 AM](https://user-images.githubusercontent.com/20543103/73551123-d6fa0b80-4413-11ea-9680-bfedc1108ee8.png)

