### PR TITLE
fix(SlateAsInputEditor): return from onChange if read only

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -423,6 +423,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
   }, [editorProps, plugins]);
 
   const onChangeHandler = ({ value }) => {
+    if (props.readOnly) return;
     onChange(value);
   };
 


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

# Issue 
on change gets called when editor is in read only mode

### Changes
fix(SlateAsInputEditor): return from onChange if read only
