### PR TITLE
(fix) backspace over a softbreak

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "plugins": ["@babel/plugin-transform-runtime"],
   "presets": ["@babel/preset-env", "@babel/preset-react"],
   "env": {
     "test": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/markdown-editor",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2284,30 +2284,36 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.4.tgz",
-      "integrity": "sha512-O8kSkS5fP74Ad/8pfsCMGa8sBRdLxYoSReaARRNSz3FbFQj3z/QUvoUmJ28gn9BO93YfnXc3j+Xyaqe8cKDNBQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz",
+      "integrity": "sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.7.4",
-        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
         "resolve": "^1.8.1",
         "semver": "^5.5.1"
       },
       "dependencies": {
         "@babel/helper-module-imports": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
-          "integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+          "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.7.4"
+            "@babel/types": "^7.8.3"
           }
         },
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        },
         "@babel/types": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-          "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -2919,9 +2925,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
-      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -5257,6 +5263,18 @@
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-runtime": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.4.tgz",
+          "integrity": "sha512-O8kSkS5fP74Ad/8pfsCMGa8sBRdLxYoSReaARRNSz3FbFQj3z/QUvoUmJ28gn9BO93YfnXc3j+Xyaqe8cKDNBQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.7.4",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "resolve": "^1.8.1",
+            "semver": "^5.5.1"
           }
         },
         "@babel/plugin-transform-shorthand-properties": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@babel/cli": "^7.7.0",
     "@babel/core": "^7.7.2",
     "@babel/plugin-transform-modules-commonjs": "^7.7.0",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.7.0",
@@ -100,8 +101,9 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@accordproject/markdown-slate": "^0.9.8",
     "@accordproject/markdown-html": "^0.9.8",
+    "@accordproject/markdown-slate": "^0.9.8",
+    "@babel/runtime": "^7.8.4",
     "css-loader": "^3.2.0",
     "immutable": "^3.8.2",
     "is-hotkey": "^0.1.6",

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -159,7 +159,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
       case 'html_inline':
         return <span className='html_inline' {...attributes}>{children}</span>;
       case 'softbreak':
-        return ' ';
+        return <span className='softbreak' {...attributes}> {children}</span>;
       case 'linebreak':
         return <br className='linebreak' {...attributes}/>;
       default:

--- a/src/schema.js
+++ b/src/schema.js
@@ -29,10 +29,10 @@ const schema = {
   },
   inlines: {
     linebreak: {
-      isVoid: true,
+      isVoid: false,
     },
     softbreak: {
-      isVoid: true,
+      isVoid: false,
     },
     html_inline: {
     },

--- a/src/schema.js
+++ b/src/schema.js
@@ -29,10 +29,10 @@ const schema = {
   },
   inlines: {
     linebreak: {
-      isVoid: false,
+      isVoid: true,
     },
     softbreak: {
-      isVoid: false,
+      isVoid: true,
     },
     html_inline: {
     },


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

# Issue #223 

Allow backspace of a soft break.

### Changes
- Render a softbreak as a `span` so that Slate can track the DOM

### Flags
- Could not reproduce any issues with backspace inside lists in either Safari or Chrome


The code functions differently when running locally vs on Netlify.
https://deploy-preview-232--accordproject-markdown-editor.netlify.com/examples/

I see backspace issues when testing the Netlify version. Investigating...
