### PR TITLE
feat(blockquote): add ability to break out of block quote - 218

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -31,6 +31,7 @@ import baseSchema from '../schema';
 import PluginManager from '../PluginManager';
 import FormatToolbar from '../FormattingToolbar';
 import ListPlugin from '../plugins/list';
+import BlockquotePlugin from '../plugins/blockquote';
 import * as action from '../FormattingToolbar/toolbarMethods';
 
 import '../styles.css';
@@ -112,9 +113,9 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
 
   const plugins = React.useMemo(() => (props.plugins
     ? props.plugins.concat(
-      [ListPlugin()]
+      [ListPlugin(), BlockquotePlugin()]
     )
-    : [ListPlugin()]), [props.plugins]);
+    : [ListPlugin(), BlockquotePlugin()]), [props.plugins]);
 
   /**
    * A reference to the Slate Editor.
@@ -191,8 +192,6 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
         return <Heading as="h6" {...attributes}>{children}</Heading>;
       case 'horizontal_rule':
         return <hr {...attributes} />;
-      case 'block_quote':
-        return <blockquote {...attributes}>{children}</blockquote>;
       case 'code_block':
         return <pre {...attributes}>{children}</pre>;
       case 'html_block':

--- a/src/plugins/blockquote.js
+++ b/src/plugins/blockquote.js
@@ -13,12 +13,12 @@ function Blockquote() {
    * @param {Editor} editor
    * @param {Function} next
    */
-  const onEnterOrBackspace = (event, editor, next) => {
+  const onEnter = (event, editor, next) => {
     const { value } = editor;
     const { startBlock } = value;
     event.preventDefault();
 
-    // Hitting enter or backspace on an empty line will break out of block quote
+    // Hitting enter on an empty line will break out of the block quote
     if (isSelectionInput(value, BLOCK_QUOTE) && startBlock.text.length === 0) {
       editor.withoutNormalizing(() => {
         event.preventDefault();
@@ -37,11 +37,40 @@ function Blockquote() {
    * @param {Editor} editor
    * @param {Function} next
    */
+  const onBackspace = (event, editor, next) => {
+    const { value } = editor;
+    const { startBlock } = value;
+    event.preventDefault();
+
+    // Hitting backspace on the last item when empty will break out of the block quote
+    if (isSelectionInput(value, BLOCK_QUOTE) && startBlock.text.length === 0) {
+      const lastItem = !value.document.getAncestors(value.previousBlock.key)
+        .some(a => a.type === BLOCK_QUOTE);
+      if (lastItem) {
+        editor.withoutNormalizing(() => {
+          event.preventDefault();
+          editor
+            .setBlocks(PARAGRAPH)
+            .unwrapBlock(BLOCK_QUOTE);
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+
+  /**
+   * @param {Event} event
+   * @param {Editor} editor
+   * @param {Function} next
+   */
   const onKeyDown = (event, editor, next) => {
     switch (event.key) {
       case 'Enter':
+        return onEnter(event, editor, next);
       case 'Backspace':
-        return onEnterOrBackspace(event, editor, next);
+        return onBackspace(event, editor, next);
       default:
         return next();
     }

--- a/src/plugins/blockquote.js
+++ b/src/plugins/blockquote.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { BLOCK_QUOTE, PARAGRAPH } from '../constants';
+import { isSelectionInput } from '../FormattingToolbar/toolbarMethods';
+
+/**
+ * This is a plugin into the markdown editor to handle block quotes
+ */
+function Blockquote() {
+  const name = 'blockquote';
+
+  /**
+   * @param {Event} event
+   * @param {Editor} editor
+   * @param {Function} next
+   */
+  const onEnterOrBackspace = (event, editor, next) => {
+    const { value } = editor;
+    const { startBlock } = value;
+    event.preventDefault();
+
+    // Hitting enter or backspace on an empty line will break out of block quote
+    if (isSelectionInput(value, BLOCK_QUOTE) && startBlock.text.length === 0) {
+      editor.withoutNormalizing(() => {
+        event.preventDefault();
+        editor
+          .setBlocks(PARAGRAPH)
+          .unwrapBlock(BLOCK_QUOTE);
+      });
+      return;
+    }
+
+    next();
+  };
+
+  /**
+   * @param {Event} event
+   * @param {Editor} editor
+   * @param {Function} next
+   */
+  const onKeyDown = (event, editor, next) => {
+    switch (event.key) {
+      case 'Enter':
+      case 'Backspace':
+        return onEnterOrBackspace(event, editor, next);
+      default:
+        return next();
+    }
+  };
+
+  /**
+   * @param {Object} props
+   * @param {Editor} editor
+   * @param {Function} next
+   */
+  const renderBlock = (props, editor, next) => {
+    const { node, attributes, children } = props;
+
+    switch (node.type) {
+      case BLOCK_QUOTE:
+        return <blockquote {...attributes}>{children}</blockquote>;
+      default:
+        return next();
+    }
+  };
+
+  return {
+    name,
+    onKeyDown,
+    renderBlock
+  };
+}
+
+export default Blockquote;


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

# Issue #218 

### Changes
- feat(blockquote): add ability to break out of block quote

I followed the same behavior that Slab has:
- Hitting enter empty line will break out of the block quote
- Backspacing on the last item when empty will break out of the block quote

### Related Issues
#225 - The slate dom portion of issue 225 issue is giving me more trouble than I expected, so I will leave that for a separate PR (cc @jeromesimeon)