### PR TITLE
chore(dep) Upgrade to Markdown Transform 0.9.9, remove obsolete 'quote'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/markdown-editor",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,12 +38,12 @@
       }
     },
     "@accordproject/markdown-cicero": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.9.8.tgz",
-      "integrity": "sha512-pAdb6GlukxU8NGx6uWdKsGSVt5GEoZ/E7CD/pTV/5CpdaP1z3NvY1MdRcwOa64Lu+KmT99yxB5FZYSGW3v4MpA==",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.9.9.tgz",
+      "integrity": "sha512-5QH9+MRtRWkvA6qWK8tGlpmj7Xma/S+qNGLcnlFdOY331ADN8etXM6CrreI4PGuC1R6ScYvLZP1V9Jr8/ZOvCw==",
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
-        "@accordproject/markdown-common": "0.9.8",
+        "@accordproject/markdown-common": "0.9.9",
         "commonmark": "^0.29.0",
         "jsome": "2.5.0",
         "sax": "^1.2.4",
@@ -52,9 +52,9 @@
       }
     },
     "@accordproject/markdown-common": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.9.8.tgz",
-      "integrity": "sha512-da00f4xVL3+rPgb98MhPRZmrU/g9pNG25xKf8JFTYe1iwpOzrFx9i/X9b0XYCNP2cRqn4w3JxEkJPxoNwJ7guA==",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.9.9.tgz",
+      "integrity": "sha512-xHDdWay84TNMTY2yy0b/2X1cPrQl62A5tuIL0Lehfv2d3g6QHDNLDNW38yFGAiFjUIgaDXrqhMeXDJuX1XN3Rw==",
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
         "commonmark": "^0.29.0",
@@ -65,12 +65,12 @@
       }
     },
     "@accordproject/markdown-html": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.9.8.tgz",
-      "integrity": "sha512-fJd0L1ghqB0lG2JAGbox/rYO/ri6xPSkuv8io3B90RtfF5DUcGEFmZ7jvCoUmLuALNEL1sNc4LV1aDHHFINV/Q==",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.9.9.tgz",
+      "integrity": "sha512-A8lvHyQAlqnYAWB0SdjPm9LcWq0f572zpQsWG+NQn18c1g7Kx/Q7QBfGzv50te2O2UrW6eou7WrTU/wwoehFXw==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.9.8",
-        "@accordproject/markdown-common": "0.9.8",
+        "@accordproject/markdown-cicero": "0.9.9",
+        "@accordproject/markdown-common": "0.9.9",
         "jsdom": "^15.2.1",
         "type-of": "^2.0.1"
       },
@@ -171,11 +171,11 @@
       }
     },
     "@accordproject/markdown-slate": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.9.8.tgz",
-      "integrity": "sha512-0LgSr+tEoBOqDKaDI7sCXxMMF8YGhcQWi6iUaxSgX8OueYnmYwSBEYpr+ebcU6EoGqLAhe7bCYT89SeOIzwARw==",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.9.9.tgz",
+      "integrity": "sha512-8x4+R316ZJC3sFSHDlI6lcIjrsFUClD8LWxt6fXRdF8t0dVzr19h0hQbC2AdOSs27WMNoTpjYbAA3xqpNfhNFg==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.9.8"
+        "@accordproject/markdown-cicero": "0.9.9"
       }
     },
     "@babel/cli": {
@@ -3077,9 +3077,9 @@
       "dev": true
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
       "dev": true
     },
     "@hapi/joi": {

--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@accordproject/markdown-html": "^0.9.8",
-    "@accordproject/markdown-slate": "^0.9.8",
+    "@accordproject/markdown-html": "^0.9.9",
+    "@accordproject/markdown-slate": "^0.9.9",
     "@babel/runtime": "^7.8.4",
     "css-loader": "^3.2.0",
     "immutable": "^3.8.2",

--- a/src/schema.js
+++ b/src/schema.js
@@ -4,7 +4,6 @@ const schema = {
       {
         match: [
           { type: 'paragraph' },
-          { type: 'quote' },
           { type: 'list' },
           { type: 'link' },
           { type: 'horizontal_rule' },
@@ -63,11 +62,6 @@ const schema = {
       nodes: [
         { match: { type: 'paragraph' } },
       ]
-    },
-    quote: {
-      nodes: [
-        { match: { object: 'text' } },
-      ],
     },
     horizontal_rule: {
       isVoid: false,


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

## Flags
- Also addresses the markdown-editor side of https://github.com/accordproject/markdown-transform/issues/174