### PR TITLE
chore(dep) Markdown Transform 0.9.10 ; Fix for html_inline node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/markdown-editor",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,12 +38,12 @@
       }
     },
     "@accordproject/markdown-cicero": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.9.9.tgz",
-      "integrity": "sha512-5QH9+MRtRWkvA6qWK8tGlpmj7Xma/S+qNGLcnlFdOY331ADN8etXM6CrreI4PGuC1R6ScYvLZP1V9Jr8/ZOvCw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.9.10.tgz",
+      "integrity": "sha512-GNH4eiI/l86BwPxeGPgZNpZfYM+KNKpzlM9AYgabTNPtPXJ0bSHe7l8mGighDgw2teQF1webzXKch53/+TpXRA==",
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
-        "@accordproject/markdown-common": "0.9.9",
+        "@accordproject/markdown-common": "0.9.10",
         "commonmark": "^0.29.0",
         "jsome": "2.5.0",
         "sax": "^1.2.4",
@@ -52,9 +52,9 @@
       }
     },
     "@accordproject/markdown-common": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.9.9.tgz",
-      "integrity": "sha512-xHDdWay84TNMTY2yy0b/2X1cPrQl62A5tuIL0Lehfv2d3g6QHDNLDNW38yFGAiFjUIgaDXrqhMeXDJuX1XN3Rw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.9.10.tgz",
+      "integrity": "sha512-7Z99PdJ2GNGFTiUosExNq8E65v5Vw3BpmrzzicKi2zIU5+s5lZU198eiCUYZvxhngcilPAX6tPxG1Yds2aRlAA==",
       "requires": {
         "@accordproject/concerto-core": "^0.82.6",
         "commonmark": "^0.29.0",
@@ -65,12 +65,12 @@
       }
     },
     "@accordproject/markdown-html": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.9.9.tgz",
-      "integrity": "sha512-A8lvHyQAlqnYAWB0SdjPm9LcWq0f572zpQsWG+NQn18c1g7Kx/Q7QBfGzv50te2O2UrW6eou7WrTU/wwoehFXw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.9.10.tgz",
+      "integrity": "sha512-4eeO3alQL5WB5ae4Qn3FNMCthJTn64vJ3SKbXzqQGt+LtRYlJ5ru2Xqq5ymSHdwvG4y+eIuzjUL/6I+B/fcOqw==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.9.9",
-        "@accordproject/markdown-common": "0.9.9",
+        "@accordproject/markdown-cicero": "0.9.10",
+        "@accordproject/markdown-common": "0.9.10",
         "jsdom": "^15.2.1",
         "type-of": "^2.0.1"
       },
@@ -171,11 +171,11 @@
       }
     },
     "@accordproject/markdown-slate": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.9.9.tgz",
-      "integrity": "sha512-8x4+R316ZJC3sFSHDlI6lcIjrsFUClD8LWxt6fXRdF8t0dVzr19h0hQbC2AdOSs27WMNoTpjYbAA3xqpNfhNFg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.9.10.tgz",
+      "integrity": "sha512-VxqCrYfmyn8gisEaCLjfUg+cianI/BJFj6u1Jmli4PwXPk3YTAU4u1tzUPnbusj1M0ca4DI85ae803ILJ/gIxw==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.9.9"
+        "@accordproject/markdown-cicero": "0.9.10"
       }
     },
     "@babel/cli": {
@@ -18540,9 +18540,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@accordproject/markdown-html": "^0.9.9",
-    "@accordproject/markdown-slate": "^0.9.9",
+    "@accordproject/markdown-html": "^0.9.10",
+    "@accordproject/markdown-slate": "^0.9.10",
     "@babel/runtime": "^7.8.4",
     "css-loader": "^3.2.0",
     "immutable": "^3.8.2",

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -158,7 +158,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
       case 'image':
         return <img {...attributes} alt={node.data.get('title')} src={node.data.get('href')}/>;
       case 'html_inline':
-        return <span className='html_inline' {...attributes}>{children}</span>;
+        return <span className='html_inline' {...attributes}>{node.data.get('content')}</span>;
       case 'softbreak':
         return <span className='softbreak' {...attributes}> {children}</span>;
       case 'linebreak':


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

**Flags**
- HTML Inlines show as blue (styling?)
- Backspace deletes the whole inline, is that what we want?

<img width="699" alt="Screenshot 2020-02-15 at 1 59 52 PM" src="https://user-images.githubusercontent.com/670099/74593651-7534c680-4ffb-11ea-9c7d-fe8878d9640e.png">
