### PR TITLE
style: Make global styles scoped to components

### DIFF
--- a/src/MarkdownAsInputEditor/index.js
+++ b/src/MarkdownAsInputEditor/index.js
@@ -42,19 +42,19 @@ function MarkdownAsInputEditor(props) {
   /**
    * Render the component, based on showSlate
    */
-  const card = <Card fluid>
-  <Card.Content>
-  <TextareaAutosize
-    className={'textarea'}
-    width={'100%'}
-    placeholder={props.markdown}
-    value={props.markdown}
-    // eslint-disable-next-line no-unused-vars
-    onChange={onChangeHandler}
-    readOnly={props.readOnly}
-  />
-  </Card.Content>
-</Card>;
+  const card = <Card className="ap-markdown-editor" fluid>
+    <Card.Content>
+    <TextareaAutosize
+      className={'textarea'}
+      width={'100%'}
+      placeholder={props.markdown}
+      value={props.markdown}
+      // eslint-disable-next-line no-unused-vars
+      onChange={onChangeHandler}
+      readOnly={props.readOnly}
+    />
+    </Card.Content>
+  </Card>;
 
   return (
     <div>

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -440,7 +440,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
   };
 
   return (
-    <div>
+    <div className="ap-markdown-editor">
       <ToolbarWrapper {...editorProps} id="slate-toolbar-wrapper-id" />
       <EditorWrapper {...editorProps} >
         <Editor

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,19 +1,5 @@
 /*** src/styles.css ***/
-body {
-    font-family: serif;
-    font-style: normal;
-    font-weight: normal;
-    font-size: medium;
-    line-height: 100%;
-    word-spacing: normal;
-    letter-spacing: normal;
-    text-decoration: none;
-    text-transform: none;
-    text-align: left;
-    text-indent: 0ex;
-}
-
-.hr {
+.ap-markdown-editor .hr {
     overflow: visible; /* For IE */
     padding: 0;
     border: none;
@@ -22,25 +8,26 @@ body {
     text-align: center;
 }
 
-a {
+.ap-markdown-editor a{
     cursor: pointer;
 }
 
-.textarea {
+.ap-markdown-editor .textarea {
+    font-family: monospace;
     height: 100%;
     width: 100%;
     border: 0;
 }
 
-.error {
+.ap-markdown-editor .error {
     color: red;
 }
 
-.html_inline {
+.ap-markdown-editor .html_inline {
     color: rgb(0, 60, 255);
 }
 
-#slate-toolbar-wrapper-id {
+.ap-markdown-editor #slate-toolbar-wrapper-id {
     display: grid;
     grid-template-columns: 3% auto 3%;
     grid-template-rows: 100%;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,8 +44,10 @@ module.exports = {
   node: {
     fs: 'empty'
   },
-  plugins: [htmlWebpackPlugin,
-        new webpack.IgnorePlugin(/jsdom$/)],
+  plugins: [
+    htmlWebpackPlugin,
+    new webpack.IgnorePlugin(/jsdom$/)
+  ],
   resolve: {
     extensions: ['.js', '.jsx'],
   },


### PR DESCRIPTION
# Issue
The use of global styles in `src/styles.css` such as `body { ... }` is not good practice because it could modify the global styling of client applications that use these components.

### Changes
- Removed all `body` styles
- All other styles are now scoped to a class `ap-markdown-editor`