### PR TITLE
feat(FormattingToolbar): ability to open links - #213

### DIFF
--- a/src/FormattingToolbar/LinkComponent/index.js
+++ b/src/FormattingToolbar/LinkComponent/index.js
@@ -59,7 +59,7 @@ const calculateLinkPopupPosition = (editor, openSetLink, setLinkFormPopup) => {
   return {
     // Disable semantic ui popup placement by overriding `transform`
     // and use our computed `top` and `left` values
-    popupStyle: { top, left, transform: 'none', width:'400px' },
+    popupStyle: { top, left, transform: 'none', width:'400px', },
     popupPosition,
   };
 };

--- a/src/FormattingToolbar/LinkComponent/index.js
+++ b/src/FormattingToolbar/LinkComponent/index.js
@@ -20,7 +20,7 @@ const calculateLinkPopupPosition = (editor, openSetLink, setLinkFormPopup) => {
     return {
       popupPosition,
       // Hide the popup by setting negative zIndex
-      popupStyle: { zIndex: -1 }
+      popupStyle: { zIndex: -1}
     };
   }
 
@@ -59,7 +59,7 @@ const calculateLinkPopupPosition = (editor, openSetLink, setLinkFormPopup) => {
   return {
     // Disable semantic ui popup placement by overriding `transform`
     // and use our computed `top` and `left` values
-    popupStyle: { top, left, transform: 'none' },
+    popupStyle: { top, left, transform: 'none', width:'400px' },
     popupPosition,
   };
 };

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
-  Button, Dropdown, Form, Input, Popup, Ref, Icon, Grid
+  Button, Dropdown, Form, Input, Popup, Ref
 } from 'semantic-ui-react';
 
 import * as action from './toolbarMethods';
@@ -91,7 +91,7 @@ const DropdownHeader3 = {
 export default class FormatToolbar extends React.Component {
   constructor() {
     super();
-    this.state = { openSetLink: false, showLinkForm: true };
+    this.state = { openSetLink: false };
     this.linkButtonRef = createRef();
     this.hyperlinkInputRef = createRef();
     this.onMouseDown = this.onMouseDown.bind(this);
@@ -107,14 +107,14 @@ export default class FormatToolbar extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     // If the form is just opened, focus the Url input field
-    if (!prevState.openSetLink && this.state.openSetLink && this.state.showLinkForm) {
+    if (!prevState.openSetLink && this.state.openSetLink) {
       this.hyperlinkInputRef.current.focus();
     }
 
     // If the form is just closed, reset the values
     // We are not using controlled form as it will make things
     // more complex, thats why using DOM api
-    if (prevState.openSetLink && !this.state.openSetLink && this.state.showLinkForm) {
+    if (prevState.openSetLink && !this.state.openSetLink) {
       const formNode = this.setLinkForm;
       if (formNode) formNode.reset();
 
@@ -241,9 +241,6 @@ export default class FormatToolbar extends React.Component {
    * Close set link form.
    */
   closeSetLinkForm() {
-    this.setLinkForm.reset();
-    this.props.editor.focus();
-    this.setState({showLinkForm: true})
     this.setState({ openSetLink: false });
   }
 
@@ -253,6 +250,8 @@ export default class FormatToolbar extends React.Component {
   submitLinkForm(event, isLink) {
     action.applyLinkUpdate(event, this.props.editor, isLink);
     this.closeSetLinkForm();
+    this.setLinkForm.reset();
+    this.props.editor.focus();
   }
 
   /**
@@ -369,21 +368,16 @@ export default class FormatToolbar extends React.Component {
     const selectedInlineHref = document.getClosestInline(selection.anchor.path);
     const selectedText = this.props.editor.value.document
       .getFragmentAtRange(this.props.editor.value.selection).text;
-    const style = {
-      borderRadius: '5px',
-      backgroundColor: styles.tooltipBg('#FFFFFF'),
-      color: styles.tooltipColor('#949CA2'),
-    };
-    let copyToClipboard = (element) =>
-    {
-    navigator.clipboard.writeText(element.href).then(() => {
-      /* clipboard successfully set */
-    })
-  }
-  let toggleEdit = () =>{
-    this.setState({showLinkForm: false});
-  }
-  console.log(isLinkBool)
+    const calculateTruncatedLinkText = (text) =>{
+      let truncatedText;
+      try{
+        truncatedText = text.slice(0,20)+(text.length>20?'...':'');
+      }catch(_){
+        truncatedText = 'link';
+      }
+      return truncatedText;
+    }
+console.log(popupStyle)
     return (
       <Ref
         innerRef={node => {
@@ -398,109 +392,57 @@ export default class FormatToolbar extends React.Component {
                 this.setLinkForm = node;
               }}
             >
-              <>
-                {(this.state.showLinkForm&&isLinkBool) ? (
-                  <>
-                    <Grid divided>
-                      <Grid.Row>
-                        <Grid.Column width={5}>
-                          <Button style={style} 
-                          animated
-                          onClick={()=>{copyToClipboard(this.textArea)}}
-                          >
-                            <Button.Content hidden>Copy</Button.Content>
-                            <Button.Content visible>
-                              <Icon name="copy" />
-                            </Button.Content>
-                          </Button>
-                        </Grid.Column>
-                        <Grid.Column width={5}>
-                          <Button style={style} 
-                          animated
-                          onClick = {()=>toggleEdit()}
-                          >
-                            <Button.Content hidden>Edit</Button.Content>
-                            <Button.Content visible>
-                              <Icon name="edit" />
-                            </Button.Content>
-                          </Button>
-                        </Grid.Column>
-                        <Grid.Column width={5}>
-                          <Button style={style} 
-                          animated
-                          onClick={this.removeLinkForm}
-                          >
-                            <Button.Content hidden>Un-link</Button.Content>
-                            <Button.Content visible>
-                              <Icon name="unlink" />
-                            </Button.Content>
-                          </Button>
-                        </Grid.Column>
-                      </Grid.Row>
-                      <Grid.Row>
-                        <Grid.Column width={16}>
-                          {selectedInlineHref ? (
-                            <a
-                              target={"__blank"}
-                              ref={(textarea) => this.textArea = textarea}
-                              href={selectedInlineHref.data.get("href")}
-                            >
-                              {selectedInlineHref.data.get("href")}
-                            </a>
-                          ) : (
-                            <p></p>
-                          )}
-                        </Grid.Column>
-                      </Grid.Row>
-                    </Grid>
-                  </>
-                ) : (
-                  <Form
-                    onSubmit={event => this.submitLinkForm(event, isLinkBool)}
+              <Form onSubmit={event => this.submitLinkForm(event, isLinkBool)}>
+                <Form.Field>
+                  <label>Link Text</label>
+                  <Input
+                    placeholder="Text"
+                    name="text"
+                    defaultValue={
+                      isLinkBool && !selectedText
+                        ? this.props.editor.value.focusText.text
+                        : this.props.editor.value.fragment.text
+                    }
+                  />
+                </Form.Field>
+                <Form.Field>
+                  <label>Link URL</label>
+                  <Input
+                    ref={this.hyperlinkInputRef}
+                    placeholder={"http://example.com"}
+                    defaultValue={
+                      isLinkBool &&
+                      action.isOnlyLink(this.props.editor) &&
+                      selectedInlineHref
+                        ? selectedInlineHref.data.get("href")
+                        : ""
+                    }
+                    name="url"
+                  />
+                </Form.Field>
+                {isLinkBool &&
+                  action.isOnlyLink(this.props.editor) &&
+                  selectedInlineHref && (
+                   <p><a href={selectedInlineHref.data.get("href")}
+                   target='_blank'
+                   >
+                      {calculateTruncatedLinkText(selectedInlineHref.data.get("href"))}
+                    </a></p>
+                  )}
+                <Form.Field>
+                  <Button
+                    secondary
+                    floated="right"
+                    disabled={!isLinkBool}
+                    onMouseDown={this.removeLinkForm}
                   >
-                    <Form.Field>
-                      <label>Link Text</label>
-                      <Input
-                        placeholder="Text"
-                        name="text"
-                        defaultValue={
-                          isLinkBool && !selectedText
-                            ? this.props.editor.value.focusText.text
-                            : this.props.editor.value.fragment.text
-                        }
-                      />
-                    </Form.Field>
-                    <Form.Field>
-                      <label>Link URL</label>
-                      <Input
-                        ref={this.hyperlinkInputRef}
-                        placeholder={"http://example.com"}
-                        defaultValue={
-                          isLinkBool &&
-                          action.isOnlyLink(this.props.editor) &&
-                          selectedInlineHref
-                            ? selectedInlineHref.data.get("href")
-                            : ""
-                        }
-                        name="url"
-                      />
-                    </Form.Field>
-                    <Form.Field>
-                      <Button
-                        secondary
-                        floated="left"
-                        disabled={!isLinkBool}
-                        onMouseDown={this.removeLinkForm}
-                      >
-                        Remove
-                      </Button>
-                      <Button primary floated="right" type="submit">
-                        Apply
-                      </Button>
-                    </Form.Field>
-                  </Form>
-                )}
-              </>
+                    Remove
+                  </Button>
+                  <Button primary floated="right" type="submit">
+                    Apply
+                  </Button>
+                </Form.Field>
+              </Form>
             </Ref>
           }
           onClose={this.closeSetLinkForm}

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -1,4 +1,4 @@
-import React, { createRef, useState } from 'react';
+import React, { createRef } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -55,6 +55,13 @@ const VertDivider = styled.div`
   place-self: center;
 `;
 
+const PopupLinkWrapper = styled.p`
+white-space : nowrap;
+overflow : hidden;
+text-overflow : ellipsis;
+max-width : 250px;
+`;
+
 /**
  * Object constructor for dropdown styling
  * @param {*} input
@@ -368,17 +375,7 @@ export default class FormatToolbar extends React.Component {
     const selectedInlineHref = document.getClosestInline(selection.anchor.path);
     const selectedText = this.props.editor.value.document
       .getFragmentAtRange(this.props.editor.value.selection).text;
-    const calculateTruncatedLinkText = (text) =>{
-      let truncatedText;
-      try{
-        truncatedText = text.slice(0,20)+(text.length>20?'...':'');
-      }catch(_){
-        truncatedText = 'link';
-      }
-      return truncatedText;
-    }
-console.log(popupStyle)
-    return (
+      return (
       <Ref
         innerRef={node => {
           this.setLinkFormPopup = node;
@@ -423,11 +420,13 @@ console.log(popupStyle)
                 {isLinkBool &&
                   action.isOnlyLink(this.props.editor) &&
                   selectedInlineHref && (
-                   <p><a href={selectedInlineHref.data.get("href")}
+                    <PopupLinkWrapper>
+                   <a href={selectedInlineHref.data.get("href")}
                    target='_blank'
                    >
-                      {calculateTruncatedLinkText(selectedInlineHref.data.get("href"))}
-                    </a></p>
+                      {selectedInlineHref.data.get("href")}
+                    </a>
+                    </PopupLinkWrapper>
                   )}
                 <Form.Field>
                   <Button


### PR DESCRIPTION
# Issue #213 
Modified popover when a link is clicked on

### Changes
- The popover will have two UI, one when there is a link present in the text selected and others when there is no link
  - When there is a link, it will show 3 buttons with the actions: Copy, Edit, Un-Link
  - When there is no link, the previous Forn will be shown, i.e. A text-field for `href` and text with two action buttons, i.e. Save and unlink
  - I have Added a state variable - `showLinkForm` to decide which UI should be shown, but the popover also depends on whether the selected is a link or not.
  - The state variable was also added because I needed to prevent the focusing of the elements in the form when the form wasn't being rendered.
- The changes show a popover similar to Google Docs

Demo -
![Peek 2020-03-02 20-28](https://user-images.githubusercontent.com/41874033/75687976-a9c7a400-5cc4-11ea-8525-810fcbee1af4.gif)

### Flags
- Link preview (metadata / og metadata) couldn't be implemented like Google Docs because of CORS.
- The way the link is being displayed needs modifications & feedback

### Related Issues
- Issue #213 
