### PR TITLE
fix(demo) Wrong URL for Semantic UI CSS in demo

### DIFF
--- a/examples/src/index.html
+++ b/examples/src/index.html
@@ -3,7 +3,7 @@
   <body class="Site">
     <head>
       <meta charset="utf-8">
-      <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.3.3/semantic.min.css"></link>
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.3.3/semantic.min.css"></link>
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.2/gh-fork-ribbon.min.css" />
       <title>Markdown Editor</title>
     </head>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const htmlWebpackPlugin = new HtmlWebpackPlugin({
   template: path.join(__dirname, 'examples/src/index.html'),
-  filename: 'examples/index.html',
+  filename: 'index.html',
 });
 module.exports = {
   entry: path.join(__dirname, 'examples/src/index.js'),


### PR DESCRIPTION
- Corrects URL for Semantic UI CSS in demo
- `index.html` is now in the top-level directory for the demo
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>
