### PR TITLE
feat(toolbarTip): added shortcut commands in tooltip based on OS - I258

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -675,7 +675,7 @@ export default class FormatToolbar extends React.Component {
             undoIcon.width(),
             undoIcon.padding(),
             undoIcon.vBox(),
-            'Undo (' + tips.MOD + '+Z)',
+            `Undo (${tips.MOD} +Z)`,
             'toolbar-2x2'
           )
       }
@@ -687,7 +687,7 @@ export default class FormatToolbar extends React.Component {
             redoIcon.width(),
             redoIcon.padding(),
             redoIcon.vBox(),
-            'Redo (' + tips.MOD + '+Y)',
+            `Redo (${tips.MOD} +Y)`,
             'toolbar-2x3'
           )
       }

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -451,7 +451,7 @@ export default class FormatToolbar extends React.Component {
 
     return (
       <Popup
-        content={'Hyperlink'}
+        content='Insert a link'
         style={style}
         position='bottom center'
         trigger={
@@ -489,7 +489,7 @@ export default class FormatToolbar extends React.Component {
 
     return (
       <Popup
-        content={tips.capitalizeWord(action)}
+        content={tips.capitalizeWord(action)} 
         style={style}
         position='bottom center'
         trigger={
@@ -648,7 +648,7 @@ export default class FormatToolbar extends React.Component {
             undoIcon.width(),
             undoIcon.padding(),
             undoIcon.vBox(),
-            'undo',
+            'Undo(' + tips.MOD + '+Z)',
             'toolbar-2x2'
           )
       }
@@ -660,7 +660,7 @@ export default class FormatToolbar extends React.Component {
             redoIcon.width(),
             redoIcon.padding(),
             redoIcon.vBox(),
-            'redo',
+            'Redo(' + tips.MOD + '+Y)',
             'toolbar-2x3'
           )
       }

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -675,7 +675,7 @@ export default class FormatToolbar extends React.Component {
             undoIcon.width(),
             undoIcon.padding(),
             undoIcon.vBox(),
-            `Undo (${tips.MOD} +Z)`,
+            'Undo (' + tips.MOD + '+Z)',
             'toolbar-2x2'
           )
       }
@@ -687,7 +687,7 @@ export default class FormatToolbar extends React.Component {
             redoIcon.width(),
             redoIcon.padding(),
             redoIcon.vBox(),
-            `Redo (${tips.MOD} +Y)`,
+            'Redo (' + tips.MOD + '+Y)',
             'toolbar-2x3'
           )
       }

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -675,7 +675,7 @@ export default class FormatToolbar extends React.Component {
             undoIcon.width(),
             undoIcon.padding(),
             undoIcon.vBox(),
-            'Undo(' + tips.MOD + '+Z)',
+            'Undo (' + tips.MOD + '+Z)',
             'toolbar-2x2'
           )
       }
@@ -687,7 +687,7 @@ export default class FormatToolbar extends React.Component {
             redoIcon.width(),
             redoIcon.padding(),
             redoIcon.vBox(),
-            'Redo(' + tips.MOD + '+Y)',
+            'Redo (' + tips.MOD + '+Y)',
             'toolbar-2x3'
           )
       }

--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -675,7 +675,7 @@ export default class FormatToolbar extends React.Component {
             undoIcon.width(),
             undoIcon.padding(),
             undoIcon.vBox(),
-            'Undo (' + tips.MOD + '+Z)',
+            `Undo (${tips.MOD}+Z)`,
             'toolbar-2x2'
           )
       }
@@ -687,7 +687,7 @@ export default class FormatToolbar extends React.Component {
             redoIcon.width(),
             redoIcon.padding(),
             redoIcon.vBox(),
-            'Redo (' + tips.MOD + '+Y)',
+            `Redo (${tips.MOD}+Y)`,
             'toolbar-2x3'
           )
       }

--- a/src/FormattingToolbar/toolbarTooltip.js
+++ b/src/FormattingToolbar/toolbarTooltip.js
@@ -21,22 +21,27 @@ function OS () {
   const {platform} = window.navigator;
 
   const macosPlatforms = {
-    os: ["Macintosh", "MacIntel", "MacPPC", "Mac68K"],
+    os: {
+      "Macintosh": true, 
+      "MacIntel": true, 
+      "MacPPC": true, 
+      "Mac68K": true
+    },
     MOD: "⌘"
   };
 
   const windowsPlatforms = {
-    os : ["Win32", "Win64", "Windows", "WinCE"],
+    os : {
+      "Win32": true, 
+      "Win64": true, 
+      "Windows": true, 
+      "WinCE": true
+    },
     MOD: "Ctrl"
   };
 
-  if (macosPlatforms.os.indexOf(platform) !== -1) {
-    return macosPlatforms.MOD;
-  }  else if (windowsPlatforms.os.indexOf(platform) !== -1) {
-    return windowsPlatforms.MOD;
-  } else if (!os && /Linux/.test(platform)) {
-    return windowsPlatforms.MOD;
-  }
+  if (macosPlatforms.os[platform]) return macosPlatforms.MOD;
+  return windowsPlatforms.MOD;
 }
 
 export const MOD = OS();

--- a/src/FormattingToolbar/toolbarTooltip.js
+++ b/src/FormattingToolbar/toolbarTooltip.js
@@ -18,24 +18,25 @@ const firstTwoLetters = word => word.toString().slice(0, 2);
  */
 
 function OS () {
-  var userAgent = window.navigator.userAgent,
-      platform = window.navigator.platform,
-      macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'],
-      windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'],
-      os = null,
-      MOD = null;
+  const {platform} = window.navigator;
 
-  if (macosPlatforms.indexOf(platform) !== -1) {
-    os = 'Mac OS';
-    MOD = '⌘';
-  }  else if (windowsPlatforms.indexOf(platform) !== -1) {
-    os = 'Windows';
-    MOD = 'Ctrl';
+  const macosPlatforms = {
+    os: ["Macintosh", "MacIntel", "MacPPC", "Mac68K"],
+    MOD: "⌘"
+  };
+
+  const windowsPlatforms = {
+    os : ["Win32", "Win64", "Windows", "WinCE"],
+    MOD: "Ctrl"
+  };
+
+  if (macosPlatforms.os.indexOf(platform) !== -1) {
+    return macosPlatforms.MOD;
+  }  else if (windowsPlatforms.os.indexOf(platform) !== -1) {
+    return windowsPlatforms.MOD;
   } else if (!os && /Linux/.test(platform)) {
-    os = 'Linux';
-    MOD = 'Ctrl';
+    return windowsPlatforms.MOD;
   }
-  return MOD; 
 }
 
 export const MOD = OS();
@@ -56,8 +57,8 @@ export const capitalizeWord = word => capitalizeFirst(word) + sliceWord(word);
 
 export const identifyBlock = (block) => {
   const typeBeginning = firstTwoLetters(block);
-    if(typeBeginning === 'bl') return 'Blockquote(' + MOD + '+Q)';
-    if(typeBeginning === 'ul') return 'Unordered List(' + MOD + '+Shift+8)';
-    if(typeBeginning === 'ol') return 'Ordered List(' + MOD + '+Shift+7)';
+    if(typeBeginning === 'bl') return 'Quote (' + MOD + '+Q)';
+    if(typeBeginning === 'ul') return 'Bulleted List (' + MOD + '+Shift+8)';
+    if(typeBeginning === 'ol') return 'Numbered List (' + MOD + '+Shift+7)';
   return null;
 };

--- a/src/FormattingToolbar/toolbarTooltip.js
+++ b/src/FormattingToolbar/toolbarTooltip.js
@@ -52,8 +52,8 @@ export const capitalizeWord = word => capitalizeFirst(word) + sliceWord(word);
 
 export const identifyBlock = (block) => {
   const typeBeginning = firstTwoLetters(block);
-    if(typeBeginning === 'bl') return 'Quote (' + MOD + '+Q)';
-    if(typeBeginning === 'ul') return 'Bulleted List (' + MOD + '+Shift+8)';
-    if(typeBeginning === 'ol') return 'Numbered List (' + MOD + '+Shift+7)';
+    if(typeBeginning === 'bl') return `Quote (${MOD}+Q)`;
+    if(typeBeginning === 'ul') return `Bulleted List (${MOD}+Shift+8)`;
+    if(typeBeginning === 'ol') return `Numbered List (${MOD}+Shift+7)`;
   return null;
 };

--- a/src/FormattingToolbar/toolbarTooltip.js
+++ b/src/FormattingToolbar/toolbarTooltip.js
@@ -52,8 +52,8 @@ export const capitalizeWord = word => capitalizeFirst(word) + sliceWord(word);
 
 export const identifyBlock = (block) => {
   const typeBeginning = firstTwoLetters(block);
-    if(typeBeginning === 'bl') return `Quote (${MOD}+Q)`;
-    if(typeBeginning === 'ul') return `Bulleted List (${MOD}+Shift+8)`;
-    if(typeBeginning === 'ol') return `Numbered List (${MOD}+Shift+7)`;
+    if(typeBeginning === 'bl') return 'Quote (' + MOD + '+Q)';
+    if(typeBeginning === 'ul') return 'Bulleted List (' + MOD + '+Shift+8)';
+    if(typeBeginning === 'ol') return 'Numbered List (' + MOD + '+Shift+7)';
   return null;
 };

--- a/src/FormattingToolbar/toolbarTooltip.js
+++ b/src/FormattingToolbar/toolbarTooltip.js
@@ -5,11 +5,40 @@
 /**
  * Methods for conversion to strings and further manipulation.
  */
+
 const capitalizeFirst = word => word.toString().charAt(0).toUpperCase();
 
 const sliceWord = word => word.toString().slice(1);
 
 const firstTwoLetters = word => word.toString().slice(0, 2);
+
+
+/**
+ * Function to determine OS and MOD command of user
+ */
+
+function OS () {
+  var userAgent = window.navigator.userAgent,
+      platform = window.navigator.platform,
+      macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'],
+      windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'],
+      os = null,
+      MOD = null;
+
+  if (macosPlatforms.indexOf(platform) !== -1) {
+    os = 'Mac OS';
+    MOD = '⌘';
+  }  else if (windowsPlatforms.indexOf(platform) !== -1) {
+    os = 'Windows';
+    MOD = 'Ctrl';
+  } else if (!os && /Linux/.test(platform)) {
+    os = 'Linux';
+    MOD = 'Ctrl';
+  }
+  return MOD; 
+}
+
+export const MOD = OS();
 
 /**
  *************** EXTERNAL METHODS ***************
@@ -18,15 +47,17 @@ const firstTwoLetters = word => word.toString().slice(0, 2);
 /**
  * Converts an input into a string, capitalizes the first letter, and returns string
  */
+
 export const capitalizeWord = word => capitalizeFirst(word) + sliceWord(word);
 
 /**
  * Checks the beginning of a block type to determine the string to return
  */
+
 export const identifyBlock = (block) => {
   const typeBeginning = firstTwoLetters(block);
-  if (typeBeginning === 'bl') return 'Quote';
-  if (typeBeginning === 'ul') return 'Bulleted List';
-  if (typeBeginning === 'ol') return 'Numbered List';
+    if(typeBeginning === 'bl') return 'Blockquote(' + MOD + '+Q)';
+    if(typeBeginning === 'ul') return 'Unordered List(' + MOD + '+Shift+8)';
+    if(typeBeginning === 'ol') return 'Ordered List(' + MOD + '+Shift+7)';
   return null;
 };

--- a/src/FormattingToolbar/toolbarTooltip.js
+++ b/src/FormattingToolbar/toolbarTooltip.js
@@ -30,18 +30,8 @@ function OS () {
     MOD: "⌘"
   };
 
-  const windowsPlatforms = {
-    os : {
-      "Win32": true, 
-      "Win64": true, 
-      "Windows": true, 
-      "WinCE": true
-    },
-    MOD: "Ctrl"
-  };
-
   if (macosPlatforms.os[platform]) return macosPlatforms.MOD;
-  return windowsPlatforms.MOD;
+  return 'Ctrl';
 }
 
 export const MOD = OS();

--- a/src/icons/bold.js
+++ b/src/icons/bold.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => `Bold (${tips.MOD}+B)`;
+export const type = () => 'Bold (' + tips.MOD + '+B)';
 
 export const height = () => '25px';
 

--- a/src/icons/bold.js
+++ b/src/icons/bold.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => 'Bold(' + tips.MOD + '+B)';
+export const type = () => 'Bold (' + tips.MOD + '+B)';
 
 export const height = () => '25px';
 

--- a/src/icons/bold.js
+++ b/src/icons/bold.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => 'Bold (' + tips.MOD + '+B)';
+export const type = () => `Bold (${tips.MOD}+B)`;
 
 export const height = () => '25px';
 

--- a/src/icons/bold.js
+++ b/src/icons/bold.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export const type = () => 'bold';
+import * as tips from '../FormattingToolbar/toolbarTooltip';
+
+export const type = () => 'Bold(' + tips.MOD + '+B)';
 
 export const height = () => '25px';
 

--- a/src/icons/code.js
+++ b/src/icons/code.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => `Code (${tips.MOD}+Alt+C)`;
+export const type = () => 'Code (' + tips.MOD + "+Alt+C)";
 
 export const height = () => '25px';
 

--- a/src/icons/code.js
+++ b/src/icons/code.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => 'Code (' + tips.MOD + "+Alt+C)";
+export const type = () => `Code (${tips.MOD}+Alt+C)`;
 
 export const height = () => '25px';
 

--- a/src/icons/code.js
+++ b/src/icons/code.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export const type = () => 'code';
+import * as tips from '../FormattingToolbar/toolbarTooltip';
+
+export const type = () => 'Code(' + tips.MOD + "+Alt+C)";
 
 export const height = () => '25px';
 

--- a/src/icons/code.js
+++ b/src/icons/code.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => 'Code(' + tips.MOD + "+Alt+C)";
+export const type = () => 'Code (' + tips.MOD + "+Alt+C)";
 
 export const height = () => '25px';
 

--- a/src/icons/italic.js
+++ b/src/icons/italic.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => `Italic (${tips.MOD} +I)`;
+export const type = () => 'Italic (' + tips.MOD + '+I)';
 
 export const height = () => '25px';
 

--- a/src/icons/italic.js
+++ b/src/icons/italic.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => 'Italic (' + tips.MOD + '+I)';
+export const type = () => `Italic (${tips.MOD} +I)`;
 
 export const height = () => '25px';
 

--- a/src/icons/italic.js
+++ b/src/icons/italic.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export const type = () => 'italic';
+import * as tips from '../FormattingToolbar/toolbarTooltip';
+
+export const type = () => 'Italic(' + tips.MOD + '+I)';
 
 export const height = () => '25px';
 

--- a/src/icons/italic.js
+++ b/src/icons/italic.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => 'Italic (' + tips.MOD + '+I)';
+export const type = () => `Italic (${tips.MOD}+I)`;
 
 export const height = () => '25px';
 

--- a/src/icons/italic.js
+++ b/src/icons/italic.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as tips from '../FormattingToolbar/toolbarTooltip';
 
-export const type = () => 'Italic(' + tips.MOD + '+I)';
+export const type = () => 'Italic (' + tips.MOD + '+I)';
 
 export const height = () => '25px';
 


### PR DESCRIPTION
Signed-off-by: Shrey Sachdeva <shreysachdeva.2000@gmail.com>

# Issue #258 
<OVERALL SUMMARY OF PULL REQUEST>

### Changes
- Added shortcut commands in `toolbarTooltip` based on OS of user
- Made the quote and link formatting options more descriptive

### Screenshot
![tooltip](https://user-images.githubusercontent.com/47667325/75787880-671dce80-5d8d-11ea-9304-557661c3c287.PNG)


### Flags
- Requires testing on MacOS and Linux platforms

### Related Issues
- Issue #247 