### PR TITLE
[WIP] feat(schema,plugin): nested items - #241

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -216,22 +216,28 @@ export default class FormatToolbar extends React.Component {
     const { value } = editor;
 
     if (!lockText || pluginManager.isEditable(editor, type)) {
+      console.log(type)
       event.preventDefault();
       if (action.isClickBlockQuote(type)) {
+        console.log('action.isClickBlockQuote(type)')
         action.isSelectionList(value)
           ? action.transformListToBlockQuote(editor, type, value)
           : action.transformPtoBQSwap(editor, type);
       } else if (action.isClickHeading(type)) {
+        console.log('action.isClickHeading(type)')
         action.hasBlock(editor, type)
           ? editor.setBlocks(CONST.PARAGRAPH)
           : editor.setBlocks(type);
       } else if (action.isSelectionList(value)) {
+        console.log('action.isSelectionList(value)')
         action.currentList(value).type === type
           ? action.transformListToParagraph(editor, type)
           : action.transformListSwap(editor, type, value);
       } else if (action.isSelectionInput(value, CONST.BLOCK_QUOTE)) {
+        console.log('action.isSelectionInput(value, CONST.BLOCK_QUOTE)')
         action.transformBlockQuoteToList(editor, type);
       } else {
+        console.log('action.isSelectionInput(value, CONST.BLOCK_QUOTE)')
         action.transformParagraphToList(editor, type);
       }
     }

--- a/src/FormattingToolbar/toolbarMethods.js
+++ b/src/FormattingToolbar/toolbarMethods.js
@@ -183,8 +183,8 @@ export const currentList = value => isSelectionOLList(value) || isSelectionULLis
 export const transformListToBlockQuote = (editor, type, value) => {
   editor.withoutNormalizing(() => {
     editor
-      .unwrapBlock(CONST.LIST_ITEM)
-      .unwrapBlock(currentList(value).type)
+      //.unwrapBlock(CONST.LIST_ITEM)
+      //.unwrapBlock(currentList(value).type)
       .wrapBlock({ type, data: { tight: true } });
   });
 };
@@ -230,7 +230,7 @@ export const transformListSwap = (editor, type, value) => {
 export const transformBlockQuoteToList = (editor, type) => {
   editor.withoutNormalizing(() => {
     editor
-      .unwrapBlock(CONST.BLOCK_QUOTE)
+      //.unwrapBlock(CONST.BLOCK_QUOTE)
       .wrapBlock({ type, data: { tight: true } })
       .wrapBlock(CONST.LIST_ITEM);
   });

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -344,8 +344,8 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
         return action.transformListSwap(editor, type, editor.value);
       }
     } else if( action.isSelectionInput(editor.value, "block_quote") ) {
-      editor.unwrapBlock("block_quote");
-      return action.transformParagraphToList(editor, type);
+      //editor.unwrapBlock("block_quote");
+      return action.transformBlockQuoteToList(editor, type);
 
     }else{
       return action.transformParagraphToList(editor, type);
@@ -361,7 +361,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
     if(action.isSelectionInput(editor.value, "block_quote")){
     editor.unwrapBlock("block_quote");
     }else if(action.isSelectionList(editor.value)){
-      action.isSelectionInput(editor.value, "ol_list")?action.transformListToParagraph(editor,'ol_list'):action.transformListToParagraph(editor,'ul_list')
+      //action.isSelectionInput(editor.value, "ol_list")?action.transformListToParagraph(editor,'ol_list'):action.transformListToParagraph(editor,'ul_list')
       editor.wrapBlock("block_quote");
     }else{
       editor.wrapBlock("block_quote");

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -338,13 +338,17 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
  
   let handleList = (editor, type) => {
     if (action.isSelectionList(editor.value)) {
-      if (action.currentList(editor.value).type === type) {
-        return action.transformListToParagraph(editor, type);
-      } else {
-        return action.transformListSwap(editor, type, editor.value);
-      }
+      console.log('list')
+      // if (action.currentList(editor.value).type === type) {
+      //   return action.transformListToParagraph(editor, type);
+      // } else {
+      //   return action.transformListSwap(editor, type, editor.value);
+      // }
+      return action.transformBlockQuoteToList(editor, type);
+
     } else if( action.isSelectionInput(editor.value, "block_quote") ) {
       //editor.unwrapBlock("block_quote");
+      console.log('block')
       return action.transformBlockQuoteToList(editor, type);
 
     }else{

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -359,7 +359,8 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
  
   let handleBlockQuotes = (editor) => {
     if(action.isSelectionInput(editor.value, "block_quote")){
-    editor.unwrapBlock("block_quote");
+    //editor.unwrapBlock("block_quote");
+    editor.wrapBlock("block_quote");
     }else if(action.isSelectionList(editor.value)){
       //action.isSelectionInput(editor.value, "ol_list")?action.transformListToParagraph(editor,'ol_list'):action.transformListToParagraph(editor,'ul_list')
       editor.wrapBlock("block_quote");

--- a/src/plugins/list.js
+++ b/src/plugins/list.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as CONST from '../constants';
-import { isSelectionInput, currentList } from '../FormattingToolbar/toolbarMethods';
+import { isSelectionInput, currentList,isClickBlockQuote } from '../FormattingToolbar/toolbarMethods';
 
 /**
  * This is a plugin into the markdown editor to handle lists
@@ -51,6 +51,9 @@ function List() {
     const { value } = editor;
     if (isSelectionInput(value, CONST.LIST_ITEM)) {
       event.preventDefault();
+        if(isSelectionInput(value, CONST.BLOCK_QUOTE)){
+          return true
+        }
         editor.withoutNormalizing(() => {
         editor.unwrapBlock(CONST.LIST_ITEM)
         editor.wrapBlock({ type: currentList(value).type, data: { tight: true } }) 

--- a/src/plugins/list.js
+++ b/src/plugins/list.js
@@ -47,10 +47,33 @@ function List() {
    * @param {Editor} editor
    * @param {Function} next
    */
+  async function onTab (event, editor, next) {
+    const { value } = editor;
+    if (isSelectionInput(value, CONST.LIST_ITEM)) {
+      event.preventDefault();
+        editor.withoutNormalizing(() => {
+        editor.unwrapBlock(CONST.LIST_ITEM)
+        editor.wrapBlock({ type: currentList(value).type, data: { tight: true } }) 
+        editor.wrapBlock(CONST.LIST_ITEM)   
+          
+      });
+      return true;
+    }
+
+    return next();
+  };
+
+  /**
+   * @param {Event} event
+   * @param {Editor} editor
+   * @param {Function} next
+   */
   const onKeyDown = (event, editor, next) => {
     switch (event.key) {
       case 'Enter':
         return onEnter(event, editor, next);
+        case 'Tab':
+          return onTab(event, editor, next);
       default:
         return next();
     }

--- a/src/plugins/list.js
+++ b/src/plugins/list.js
@@ -54,16 +54,10 @@ function List() {
         editor.withoutNormalizing(() => {
         editor.unwrapBlock(CONST.LIST_ITEM)
         editor.wrapBlock({ type: currentList(value).type, data: { tight: true } }) 
+        editor.wrapBlock({ type: currentList(value).type, data: { tight: true } }) 
         editor.wrapBlock(CONST.LIST_ITEM)   
           
       });
-      event.preventDefault();
-      editor.withoutNormalizing(() => {
-      editor.unwrapBlock(CONST.LIST_ITEM)
-      editor.wrapBlock({ type: currentList(value).type, data: { tight: true } }) 
-      editor.wrapBlock(CONST.LIST_ITEM)   
-        
-    });
       return true;
     }
 

--- a/src/plugins/list.js
+++ b/src/plugins/list.js
@@ -57,6 +57,13 @@ function List() {
         editor.wrapBlock(CONST.LIST_ITEM)   
           
       });
+      event.preventDefault();
+      editor.withoutNormalizing(() => {
+      editor.unwrapBlock(CONST.LIST_ITEM)
+      editor.wrapBlock({ type: currentList(value).type, data: { tight: true } }) 
+      editor.wrapBlock(CONST.LIST_ITEM)   
+        
+    });
       return true;
     }
 

--- a/src/plugins/list.js
+++ b/src/plugins/list.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as CONST from '../constants';
 import { isSelectionInput, currentList,isClickBlockQuote } from '../FormattingToolbar/toolbarMethods';
+import isHotKey from 'is-hotkey';
 
 /**
  * This is a plugin into the markdown editor to handle lists
@@ -67,18 +68,46 @@ function List() {
     return next();
   };
 
+    /**
+   * @param {Event} event
+   * @param {Editor} editor
+   * @param {Function} next
+   */
+  async function onShiftTab (event, editor, next) {
+    const { value } = editor;
+    if (isSelectionInput(value, CONST.LIST_ITEM)) {
+      event.preventDefault();
+        if(isSelectionInput(value, CONST.BLOCK_QUOTE)){
+          return true
+        }
+        editor.withoutNormalizing(() => {
+        editor.unwrapBlock(CONST.LIST_ITEM)
+        editor.unwrapBlock({ type: currentList(value).type, data: { tight: true } }) 
+        editor.wrapBlock(CONST.LIST_ITEM)   
+        editor.unwrapBlock(CONST.LIST_ITEM)
+        editor.unwrapBlock({ type: currentList(value).type, data: { tight: true } }) 
+        editor.wrapBlock(CONST.LIST_ITEM)   
+      });
+      return true;
+    }
+
+    return next();
+  };
+
   /**
    * @param {Event} event
    * @param {Editor} editor
    * @param {Function} next
    */
   const onKeyDown = (event, editor, next) => {
-    switch (event.key) {
-      case 'Enter':
-        return onEnter(event, editor, next);
-        case 'Tab':
+    switch (true) {
+      case isHotKey('shift+Tab', event):
+        return onShiftTab(event, editor, next);
+      case event.key==='Enter':
+        return onEnter(event, editor, next);  
+      case event.key==='Tab':
           return onTab(event, editor, next);
-      default:
+        default:
         return next();
     }
   };

--- a/src/schema.js
+++ b/src/schema.js
@@ -99,6 +99,7 @@ const schema = {
         {
           match: [
             { type: 'paragraph' },
+            { type: 'block_quote' },
             { type: 'ol_list' },
             { type: 'ul_list' },
             { type: 'list_item' },

--- a/src/schema.js
+++ b/src/schema.js
@@ -83,7 +83,25 @@ const schema = {
       nodes: [
         {
           match: [
-            { type: 'paragraph' }
+            { type: 'paragraph' },
+            { type: 'block_quote' },
+          ]
+        }
+      ],
+      marks: [
+        { type: 'bold' },
+        { type: 'italic' },
+        { type: 'code' }
+      ],
+    },
+    block_quote: {
+      nodes: [
+        {
+          match: [
+            { type: 'paragraph' },
+            { type: 'ol_list' },
+            { type: 'ul_list' },
+            { type: 'list_item' },
           ]
         }
       ],

--- a/src/schema.js
+++ b/src/schema.js
@@ -70,13 +70,13 @@ const schema = {
       data: {
         tight: v => v,
       },
-      nodes: [{ match: { type: 'list_item' } }],
+      nodes: [{ match: [{ type: 'list_item' },{ type: 'ol_list' }] }],
     },
     ul_list: {
       data: {
         tight: v => v,
       },
-      nodes: [{ match: { type: 'list_item' } }],
+      nodes: [{ match: [{ type: 'list_item' },{ type: 'ul_list' }] }],
     },
     list_item: {
       parent: [{ type: 'ol_list' }, { type: 'ul_list' }],


### PR DESCRIPTION
# Issue #241 
Changes for allowing nested lists (nested quotes, lists in quotes, quotes in lists will be added shortly)

### Changes
- Added `ul_list` and `ol_list` as children of `list_item` in `schema.js`
-Added a new method, `onTab` for handling creation of nested lists,
-Added support for lists in quotes, quotes in lists via `schema` changes and editing `transformBlockQuoteToList` & `transformListToBlockQuote`
### Flags
  -There is an error whenever a user presses `Tab`, **a nested list is only created when a user presses `Tab` twice**, and the nested list should be only created when the text-cursor is placed right after the list item symbol, not when it is in the middle of the list text.
  - the error generated is `Uncaught (in promise) Error: Item node should not occur outside of List nodes`
  - I will work on adding the other nesting features, then tackle the above issues.

### Related Issues
- Issue #241 
- Pull Request #250 
- Pull Request #261 (That was a mistake) 
