### PR TITLE
style(FormattingToolbar): improve markdown-editor UI/UX - I124

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -48,9 +48,9 @@ const ToolbarIcon = styled.svg`
 
 const VertDivider = styled.div`
   box-sizing: border-box;
-  height: 24px;
-  width: 1px;
-  border: 1px solid ${props => props.color || '#EFEFEF'};
+  height: 30px;
+  width: 0.2x;
+  border: 0.5px solid ${props => props.color || '#EFEFEF'};
   top: 10px;
   place-self: center;
 `;
@@ -68,7 +68,6 @@ max-width : 250px;
  * @return {*} a new object
  */
 function DropdownStyle(input) {
-  this.color = styles.buttonSymbolActive(input);
   this.alignSelf = 'center';
 }
 
@@ -463,7 +462,7 @@ export default class FormatToolbar extends React.Component {
     const isActive = action.hasLinks(editor);
 
     const fillActivity = isActive
-      ? '#2587DA'
+      ? '#122330'
       : styles.buttonSymbolInactive(editorProps.BUTTON_SYMBOL_INACTIVE);
 
     const bgActivity = isActive

--- a/src/FormattingToolbar/toolbarStyles.js
+++ b/src/FormattingToolbar/toolbarStyles.js
@@ -3,11 +3,11 @@
  */
 export const buttonBgInactiveInactive = input => input || '#FFFFFF';
 
-export const buttonBgActive = input => input || '#F0F0F0';
+export const buttonBgActive = input => input || '#E8F0FE';
 
 export const buttonSymbolInactive = input => input || '#949CA2';
 
-export const buttonSymbolActive = input => input || '#414F58';
+export const buttonSymbolActive = input => input || '#2587DA';
 
 export const tooltipBg = input => input || '#FFFFFF';
 

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -41,9 +41,7 @@ const EditorWrapper = styled.div`
   min-height: ${props => props.EDITOR_HEIGHT || '750px'};
   max-width: ${props => props.EDITOR_WIDTH || 'none'};
   min-width: ${props => props.EDITOR_WIDTH || 'none'};
-  border-radius: ${props => props.EDITOR_BORDER_RADIUS || ' 10px'};
-  border: ${props => props.EDITOR_BORDER || ' 1px solid #979797'};
-  box-shadow: ${props => props.EDITOR_SHADOW || ' 1px 2px 4px rgba(0, 0, 0, .5)'};
+  box-shadow: ${props => props.EDITOR_SHADOW || '1px 1px 4px rgba(6,6,73, 0.1)'};
   margin: ${props => props.EDITOR_MARGIN || '5px auto'};
   font-family: serif;
   font-style: normal;
@@ -75,7 +73,9 @@ const ToolbarWrapper = styled.div`
   top: 0;
   height: 36px;
   background: ${props => props.TOOLBAR_BACKGROUND || '#FFF'};
-  box-shadow: ${props => props.TOOLBAR_SHADOW || 'none'};
+  box-shadow: ${props => props.TOOLBAR_SHADOW || '1px 1px 4px rgba(6,6,73, 0.1)'};
+  border-radius: ${props => props.TOOLBAR_BORDER_RADIUS || '5px'};
+  margin: 30px 0px; 
 `;
 
 const Heading = styled.div`
@@ -557,8 +557,6 @@ SlateAsInputEditor.propTypes = {
     BUTTON_SYMBOL_INACTIVE: PropTypes.string,
     BUTTON_SYMBOL_ACTIVE: PropTypes.string,
     DROPDOWN_COLOR: PropTypes.string,
-    EDITOR_BORDER: PropTypes.string,
-    EDITOR_BORDER_RADIUS: PropTypes.string,
     EDITOR_HEIGHT: PropTypes.string,
     EDITOR_MARGIN: PropTypes.string,
     EDITOR_SHADOW: PropTypes.string,


### PR DESCRIPTION
Signed-off-by: Shrey Sachdeva <shreysachdeva.2000@gmail.com>

Continues #247 (closed due to merge conflicts)

# Issue #124 
Enhance markdown-editor overall UI/UX

### Changes
- More subtle shadows on `FormattingToolbar` and `EditorWrapper`
- Increased spacing between `FormattingToolbar` and `EditorWrapper`
- Changed button active color to match the theme 
    - background color from '#F0F0F0' to '#E8F0FE' 
    - button active color from '#414F58' to '#2587DA' 
- Removed `EditorWrapper` border

**Old**
![2](https://user-images.githubusercontent.com/47667325/76125294-7f5a4b80-6022-11ea-9b2d-c8e976867af6.PNG)

**New**
![1](https://user-images.githubusercontent.com/47667325/76125286-779aa700-6022-11ea-8b43-146081d2cd2c.PNG)
 
### Flags
- NA

### Related Issues
- Issue #124 