### PR TITLE
fix(ToolbarMethods) Selecting list/quote option while link popup is open crashes demo - #266

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -215,7 +215,7 @@ export default class FormatToolbar extends React.Component {
     const { editor, pluginManager, lockText } = this.props;
     const { value } = editor;
 
-    if (!lockText || pluginManager.isEditable(editor, type)) {
+    if (!lockText || pluginManager.isEditable(editor, type) && !action.isOnlyLink(editor)) {
       event.preventDefault();
       if (action.isClickBlockQuote(type)) {
         action.isSelectionList(value)

--- a/src/FormattingToolbar/toolbarMethods.js
+++ b/src/FormattingToolbar/toolbarMethods.js
@@ -194,7 +194,6 @@ export const transformListToBlockQuote = (editor, type, value) => {
  */
 /* eslint no-unused-expressions: 0 */
 export const transformPtoBQSwap = (editor, type) => {
-  console.log('hi')
   !isOnlyLink(editor)&&
   (isSelectionInput(editor.value, CONST.BLOCK_QUOTE)
     ? editor.unwrapBlock(CONST.BLOCK_QUOTE)

--- a/src/FormattingToolbar/toolbarMethods.js
+++ b/src/FormattingToolbar/toolbarMethods.js
@@ -194,9 +194,11 @@ export const transformListToBlockQuote = (editor, type, value) => {
  */
 /* eslint no-unused-expressions: 0 */
 export const transformPtoBQSwap = (editor, type) => {
-  isSelectionInput(editor.value, CONST.BLOCK_QUOTE)
+  console.log('hi')
+  !isOnlyLink(editor)&&
+  (isSelectionInput(editor.value, CONST.BLOCK_QUOTE)
     ? editor.unwrapBlock(CONST.BLOCK_QUOTE)
-    : editor.wrapBlock({ type, data: { tight: true } });
+    : editor.wrapBlock({ type, data: { tight: true } }));
 };
 
 /**

--- a/src/FormattingToolbar/toolbarMethods.js
+++ b/src/FormattingToolbar/toolbarMethods.js
@@ -240,6 +240,7 @@ export const transformBlockQuoteToList = (editor, type) => {
  * A trigger to the Slate editor to make a paragraph into a list_item.
  */
 export const transformParagraphToList = (editor, type) => {
+  !isOnlyLink(editor)&&
   editor.withoutNormalizing(() => {
     editor.wrapBlock({ type, data: { tight: true } }).wrapBlock(CONST.LIST_ITEM);
   });


### PR DESCRIPTION
# Issue #266 
Now the web app doesn't crash when list options are selected when the link popover is open

### Changes
- In `ToolbarMethods.js`
  - In `transformParagraphToList` method, I have added one more condition check, ie of the text selection is only a link, The behavior of the popover is that it only opens when the selection is only a link. 
  - If the selection is only a link, then the usual conversion of the paragraph to list doesn't take place

### Flags
- Can be improved If I figure out a way to increase the selection area when the selection is only a list

### Related Issues
- Issue #266
