### PR TITLE
fix(list): converts multiple line to lists - I229

### DIFF
--- a/src/plugins/list.js
+++ b/src/plugins/list.js
@@ -70,7 +70,11 @@ function List() {
       case CONST.UL_LIST:
         return <ul {...attributes}>{children}</ul>;
       case CONST.LIST_ITEM:
-        return <li {...attributes}>{children}</li>;
+        return children.map( (child) => {
+          if (child) {
+            return <li {...attributes}>{child}</li>
+          }
+        });
       default:
         return next();
     }


### PR DESCRIPTION
Signed-off-by: elit-altum <manan.sharma311@gmail.com>

# Issue #229 

### Changes
- Changed ```list.js``` to break every element into an individual ```<li>``` tag rather than all children in a single tag
![Para-To-List-Fix](https://user-images.githubusercontent.com/41413622/76150593-45488280-60d2-11ea-8cb1-33dca70053aa.gif)

### Flags
- The editor list is getting converted fine, but the individual children still aren't being converted to individual list items in the markdown. Currently working to fix that.

### Related Issues
- Issue #229 