### PR TITLE
fix(SlateAsInputEditor): removed blank line on hitting enter after heading - I280

### DIFF
--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -327,7 +327,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
 
     // when you hit enter after a heading we insert a paragraph
     event.preventDefault();
-    editor.insertBlock(CONST.PARAGRAPH);
+    editor.insertText('');
     return next();
   };
 

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -319,15 +319,14 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
       return false;
     }
 
-    // if you hit enter inside anything that is not a heading
-    // we use the default behavior
-    if (!startBlock.type.startsWith('heading')) {
-      return next();
+    // when you hit enter after a heading we insert a paragraph
+    if (startBlock.type.startsWith('heading')) {
+      event.preventDefault();
+      return editor.insertBlock(CONST.PARAGRAPH);
     }
 
-    // when you hit enter after a heading we insert a paragraph
-    event.preventDefault();
-    editor.insertText('');
+    // if you hit enter inside anything that is not a heading
+    // we use the default behavior
     return next();
   };
 


### PR DESCRIPTION
Signed-off-by: elit-altum <manan.sharma311@gmail.com>

# Issue #280 
Removed the extra paragraph block which caused the spacing by inserting an empty text string

### Changes
- Now an empty text string is added on hitting enter instead of a paragraph which also allows multiple line headings
- A backspace on the cursor before typing the heading on the new line converts it back into a paragraph.

### Flags
- Not sure of the solution implemented would need a review

### Related Issues
- Issue #280 