### PR TITLE
style(FormattingToolbar): changed order and shortcut for code - I289-290

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -611,18 +611,6 @@ export default class FormatToolbar extends React.Component {
         } */}
         <VertDivider color={editorProps.DIVIDER} className='toolbar-4x1'/>
         {
-          this.renderMarkButton(
-            codeIcon.type(),
-            codeIcon.label(),
-            codeIcon.icon,
-            codeIcon.height(),
-            codeIcon.width(),
-            codeIcon.padding(),
-            codeIcon.vBox(),
-            'toolbar-1x0'
-          )
-        }
-        {
           this.renderBlockButton(
             quoteIcon.type(),
             quoteIcon.icon,
@@ -630,6 +618,17 @@ export default class FormatToolbar extends React.Component {
             quoteIcon.width(),
             quoteIcon.padding(),
             quoteIcon.vBox(),
+            'toolbar-1x0'
+          )
+        }
+        {
+          this.renderBlockButton(
+            oListIcon.type(),
+            oListIcon.icon,
+            oListIcon.height(),
+            oListIcon.width(),
+            oListIcon.padding(),
+            oListIcon.vBox(),
             'toolbar-1x1'
           )
         }
@@ -645,13 +644,14 @@ export default class FormatToolbar extends React.Component {
           )
         }
         {
-          this.renderBlockButton(
-            oListIcon.type(),
-            oListIcon.icon,
-            oListIcon.height(),
-            oListIcon.width(),
-            oListIcon.padding(),
-            oListIcon.vBox(),
+          this.renderMarkButton(
+            codeIcon.type(),
+            codeIcon.label(),
+            codeIcon.icon,
+            codeIcon.height(),
+            codeIcon.width(),
+            codeIcon.padding(),
+            codeIcon.vBox(),
             'toolbar-1x3'
           )
         }

--- a/src/FormattingToolbar/toolbarTooltip.js
+++ b/src/FormattingToolbar/toolbarTooltip.js
@@ -48,8 +48,8 @@ export const capitalizeWord = word => capitalizeFirst(word) + sliceWord(word);
 
 export const identifyBlock = (block) => {
   const typeBeginning = firstTwoLetters(block);
-  if (typeBeginning === 'bl') return `Quote (${MOD}+⇧+. )`;
-  if (typeBeginning === 'ul') return `Bulleted List (${MOD}+⇧+8)`;
-  if (typeBeginning === 'ol') return `Numbered List (${MOD}+⇧+7)`;
+  if (typeBeginning === 'bl') return `Quote (${MOD}+Shift+. )`;
+  if (typeBeginning === 'ul') return `Bulleted List (${MOD}+Shift+8)`;
+  if (typeBeginning === 'ol') return `Numbered List (${MOD}+Shift+7)`;
   return null;
 };

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -392,7 +392,7 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
           return editor.toggleMark(CONST.FONT_BOLD);
         case isHotKey('mod+i', event) && isEditable(editor, CONST.FONT_ITALIC):
           return editor.toggleMark(CONST.FONT_ITALIC);
-        case isHotKey('mod+alt+c', event) && isEditable(editor, CONST.FONT_CODE):
+        case isHotKey('mod+shift+9', event) && isEditable(editor, CONST.FONT_CODE):
           return editor.toggleMark(CONST.FONT_CODE);
         case isHotKey('mod+shift+.', event) && isEditable(editor, CONST.BLOCK_QUOTE):
           return handleBlockQuotes(editor);

--- a/src/icons/code.js
+++ b/src/icons/code.js
@@ -4,7 +4,7 @@ import * as tips from '../FormattingToolbar/toolbarTooltip';
 
 export const type = () => 'code';
 
-export const label = () => `Code (${tips.MOD}+Alt+C)`;
+export const label = () => `Code (${tips.MOD}+Shift+9)`;
 
 export const height = () => '25px';
 

--- a/src/icons/navigation-right.js
+++ b/src/icons/navigation-right.js
@@ -4,7 +4,7 @@ import * as tips from '../FormattingToolbar/toolbarTooltip';
 
 export const type = () => 'redo';
 
-export const label = () => `Redo (${tips.MOD}+⇧+Z)`;
+export const label = () => `Redo (${tips.MOD}+Shift+Z)`;
 
 export const height = () => '25px';
 


### PR DESCRIPTION
Signed-off-by: elit-altum <manan.sharma311@gmail.com>

# Issue #289 #290 

### Changes
- Changed the shortcut for ```code``` to ```Ctrl/Cmd+Shift+9```
- Also switched to using ```Shift``` instead of  ```⇧ ```  in tootips indicating the shortcuts, for improving user readability https://github.com/accordproject/markdown-editor/issues/290#issuecomment-598765720 

### Screenshot
![image](https://user-images.githubusercontent.com/41413622/76634329-22075280-656c-11ea-9fce-a786a0467d5a.png)

### Flags
- Shifted from https://github.com/accordproject/markdown-editor/pull/291

### Related Issues
- N/A