### PR TITLE
docs(readme): add keyboard shortcuts - #244

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,50 @@ The editor includes a formatting toolbar.
 
 This component is Apache-2 licensed Open Source. Contributors welcome!
 
+### Keyboard shortcuts
+
+The keyboard shortcuts are as follows
+
+Windows/Linux:
+
+- Common actions
+  - `CTRL` + `C` - Copy
+  - `CTRL` + `X` - Cut
+  - `CTRL` + `V` - Paste
+  - `CTRL` + `Z` - Undo
+  - `CTRL` + `SHIFT` + `Z` - Redo
+  - `CTRL` + `Y` - Repeat last action
+
+- Text formatting
+  - `CTRL` + `B` - Bold
+  - `CTRL` + `I` - Italicize 
+  - `CTRL` + `Q` - Block quotes
+  - `CTRL` + `SHIFT` + `9` - Code
+
+- Paragraph formatting
+  - `CTRL` + `SHIFT` + `7` - Numbered list
+  - `CTRL` + `SHIFT` + `8` - Bulleted list
+
+Mac:
+
+- Common actions
+  - `⌘` + `C` - Copy
+  - `⌘` + `X` - Cut
+  - `⌘` + `V` - Paste
+  - `⌘` + `Z` - Undo
+  - `⌘` + `SHIFT` + `Z` - Redo
+  - `⌘` + `Y` - Repeat last action
+
+- Text formatting
+  - `⌘` + `B` - Bold
+  - `⌘` + `I` - Italicize 
+  - `⌘` + `Q` - Block quotes
+  - `⌘` + `SHIFT` + `9` - Code
+
+- Paragraph formatting
+  - `⌘` + `SHIFT` + `7` - Numbered list
+  - `⌘` + `SHIFT` + `8` - Bulleted list
+
 ### [Demo](https://accordproject-markdown-editor.netlify.com/)
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Windows/Linux:
 - Text formatting
   - `CTRL` + `B` - Bold
   - `CTRL` + `I` - Italicize 
-  - `CTRL` + `Q` - Block quotes
+  - `CTRL` + `SHIFT` + `.` - Block quotes
   - `CTRL` + `SHIFT` + `9` - Code
 
 - Paragraph formatting
@@ -83,7 +83,7 @@ Mac:
 - Text formatting
   - `⌘` + `B` - Bold
   - `⌘` + `I` - Italicize 
-  - `⌘` + `Q` - Block quotes
+  - `⌘` + `SHIFT` + `.` - Block quotes
   - `⌘` + `SHIFT` + `9` - Code
 
 - Paragraph formatting

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Windows/Linux:
   - `CTRL` + `V` - Paste
   - `CTRL` + `Z` - Undo
   - `CTRL` + `SHIFT` + `Z` - Redo
-  - `CTRL` + `Y` - Repeat last action
 
 - Text formatting
   - `CTRL` + `B` - Bold
@@ -78,7 +77,6 @@ Mac:
   - `⌘` + `V` - Paste
   - `⌘` + `Z` - Undo
   - `⌘` + `SHIFT` + `Z` - Redo
-  - `⌘` + `Y` - Repeat last action
 
 - Text formatting
   - `⌘` + `B` - Bold


### PR DESCRIPTION
# Issue #244 
Updated readme to show the new keyboard shortcuts
### Changes
- The readme has the following text added just before the ### Demo section
------------------------------------------------
### Keyboard shortcuts

The keyboard shortcuts are as follows

Windows/Linux:

- Common actions
  - `CTRL` + `C` - Copy
  - `CTRL` + `X` - Cut
  - `CTRL` + `V` - Paste
  - `CTRL` + `Z` - Undo
  - `CTRL` + `SHIFT` + `Z` - Redo
  - `CTRL` + `Y` - Repeat last action

- Text formatting
  - `CTRL` + `B` - Bold
  - `CTRL` + `I` - Italicize 
  - `CTRL` + `Q` - Block quotes
  - `CTRL` + `SHIFT` + `9` - Code

- Paragraph formatting
  - `CTRL` + `SHIFT` + `7` - Numbered list
  - `CTRL` + `SHIFT` + `8` - Bulleted list

Mac:

- Common actions
  - `⌘` + `C` - Copy
  - `⌘` + `X` - Cut
  - `⌘` + `V` - Paste
  - `⌘` + `Z` - Undo
  - `⌘` + `SHIFT` + `Z` - Redo
  - `⌘` + `Y` - Repeat last action

- Text formatting
  - `⌘` + `B` - Bold
  - `⌘` + `I` - Italicize 
  - `⌘` + `Q` - Block quotes
  - `⌘` + `SHIFT` + `9` - Code

- Paragraph formatting
  - `⌘` + `SHIFT` + `7` - Numbered list
  - `⌘` + `SHIFT` + `8` - Bulleted list
----------------------------------------------------------

### Flags
- None

### Related Issues
- Issue #244 
- Pull Request #267 