### PR TITLE
Add shortcut for adding hyperlink to texts

### DIFF
--- a/src/FormattingToolbar/index.js
+++ b/src/FormattingToolbar/index.js
@@ -96,9 +96,9 @@ const DropdownHeader3 = {
 /* eslint-disable react/no-find-dom-node */
 
 export default class FormatToolbar extends React.Component {
-  constructor() {
-    super();
-    this.state = { openSetLink: false };
+  constructor(props) {
+    super(props);
+    this.state = { openSetLink: this.props.openSetLink};
     this.linkButtonRef = createRef();
     this.hyperlinkInputRef = createRef();
     this.onMouseDown = this.onMouseDown.bind(this);
@@ -457,7 +457,7 @@ export default class FormatToolbar extends React.Component {
   /**
    * Render a link-toggling toolbar button.
    */
-  renderLinkButtonNew(type, icon, hi, wi, pa, vBox, classInput) {
+  renderLinkButtonNew(type, label, icon, hi, wi, pa, vBox, classInput) {
     const { editor, editorProps } = this.props;
 
     const isActive = action.hasLinks(editor);
@@ -478,7 +478,7 @@ export default class FormatToolbar extends React.Component {
 
     return (
       <Popup
-        content='Insert a link'
+        content={label}
         style={style}
         position='bottom center'
         trigger={
@@ -662,6 +662,7 @@ export default class FormatToolbar extends React.Component {
         {
           this.renderLinkButtonNew(
             hyperlinkIcon.type(),
+            hyperlinkIcon.label(),
             hyperlinkIcon.icon,
             hyperlinkIcon.height(),
             hyperlinkIcon.width(),
@@ -718,4 +719,5 @@ FormatToolbar.propTypes = {
     TOOLTIP: PropTypes.string,
     DIVIDER: PropTypes.string,
   }),
+  openSetLink: PropTypes.bool.isRequired,
 };

--- a/src/SlateAsInputEditor/index.js
+++ b/src/SlateAsInputEditor/index.js
@@ -129,6 +129,11 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
   const [slateSchema, setSlateSchema] = useState(null);
 
   /**
+   * Visibility of set link form
+   */
+  const [openSetLink, setLinkFormVisibility] = useState(false);
+
+  /**
    * Updates the Slate Schema when the plugins change
    */
   useEffect(() => {
@@ -400,6 +405,8 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
           return handleList(editor, CONST.OL_LIST);
         case isHotKey('mod+shift+8', event) && isEditable(editor, CONST.UL_LIST):
           return handleList(editor, CONST.UL_LIST);
+        case isHotKey('mod+shift+k', event):
+          return setLinkFormVisibility(true);
         default:
           return next();
       }
@@ -474,11 +481,12 @@ const SlateAsInputEditor = React.forwardRef((props, ref) => {
           pluginManager={pluginManager}
           editorProps={editorProps}
           lockText={props.lockText}
+          openSetLink={openSetLink}
         />
         {children}
       </div>
     );
-  }, [editorProps, plugins]);
+  }, [editorProps, plugins, openSetLink]);
 
   const onChangeHandler = ({ value }) => {
     if (props.readOnly) return;

--- a/src/icons/hyperlink.js
+++ b/src/icons/hyperlink.js
@@ -1,6 +1,10 @@
 import React from 'react';
 
+import * as tips from '../FormattingToolbar/toolbarTooltip';
+
 export const type = () => 'link';
+
+export const label = () => `Insert a link (${tips.MOD}+Shift+K)`;
 
 export const height = () => '25px';
 


### PR DESCRIPTION
# Issue #296 
These changes aim to introduce a shortcut for adding hyperlinks.

### Changes
- I created an `openSetLink` state in `SlateAsInputEditor/index.js` using `useState` which also defined the function for updating it, called `setLinkFormVisibility`.
- Then I defined a case for a hotkey `case isHotKey('mod+shift+k', event)`. So that whenever I press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>k</kbd>, `setLinkFormVisibility` is triggered.
- Unfortunately, the state `openSetLink` is not being updated.

### Flags
- This issue is not resolved yet. I wanted to understand where I am going wrong.