### PR TITLE
feat(*): add shortcut for hyperlinking texts

### DIFF
--- a/src/RichTextEditor/components/icons/link.js
+++ b/src/RichTextEditor/components/icons/link.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MOD } from '../../utilities/tooltipHelpers';
 
 const icon = fillColor => (
   <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
@@ -17,7 +18,7 @@ const icon = fillColor => (
 
 const link = {
   type: 'link',
-  label: 'Hyperlink',
+  label: `Hyperlink (${MOD()}+K)`,
   height: '25px',
   width: '25px',
   padding: '5px',

--- a/src/RichTextEditor/index.js
+++ b/src/RichTextEditor/index.js
@@ -52,6 +52,12 @@ const RichTextEditor = (props) => {
     special: (code) => {
       if (code === 'undo') return editor.undo();
       return editor.redo();
+    },
+    link: (_) => {
+      const url = window.prompt('Enter the URL of the link:');
+      if (url) {
+        insertLink(editor, url);
+      }
     }
   };
 

--- a/src/RichTextEditor/index.js
+++ b/src/RichTextEditor/index.js
@@ -53,12 +53,9 @@ const RichTextEditor = (props) => {
       if (code === 'undo') return editor.undo();
       return editor.redo();
     },
-    link: (_) => {
-      const url = window.prompt('Enter the URL of the link:');
-      if (url) {
-        insertLink(editor, url);
-      }
-    }
+    link: () => {
+      setShowLinkModal(true);
+    },
   };
 
   const { isEditable, canBeFormatted } = props;

--- a/src/RichTextEditor/utilities/hotkeys.js
+++ b/src/RichTextEditor/utilities/hotkeys.js
@@ -40,6 +40,10 @@ const HOTKEYS = {
   'mod+shift+z': {
     type: 'special',
     code: 'redo',
+  },
+  'mod+k' : {
+    type: 'link',
+    code: LINK
   }
 };
 
@@ -49,7 +53,7 @@ export const ENTER_BREAKS = {
   [UL_LIST]: true,
 };
 
-export const formattingHotKeys = ['mod+b', 'mod+i', 'mod+shift+7', 'mod+shift+8', 'mod+shift+9', 'mod+shift+.', 'mod+shift+g'];
+export const formattingHotKeys = ['mod+b', 'mod+i', 'mod+shift+7', 'mod+shift+8', 'mod+shift+9', 'mod+shift+.', 'mod+shift+g', 'mod+k'];
 
 export const ENTER = 'enter';
 export const ENTER_SHIFT = 'shift+enter';

--- a/src/RichTextEditor/utilities/hotkeys.js
+++ b/src/RichTextEditor/utilities/hotkeys.js
@@ -43,7 +43,7 @@ const HOTKEYS = {
   },
   'mod+k' : {
     type: 'link',
-    code: LINK
+    code: LINK,
   }
 };
 


### PR DESCRIPTION
Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>

# Issue #296 
These changes aim to introduce a shortcut for adding hyperlinks.

### Changes
- Change the label of icon to `Hyperlink (${MOD()}+K)`
- Add other entry for creating a shortcut `mod+k`.
- On pressing <kbd>Ctrl</kbd> + <kbd>k</kbd>, the editor will prompt for a URL.
- The demonstration is as follows.
![accord](https://user-images.githubusercontent.com/35191225/79044549-5af61e00-7c23-11ea-9187-f4fe9ecaa9ce.gif)


### Flags
~~- Please note that currently entering the URL using `insertLink` is broken. Look at the screencast below.
![accord](https://user-images.githubusercontent.com/35191225/79044454-d86d5e80-7c22-11ea-8b47-f85142850777.gif)
The URL converted is not in the correct markdown format.~~

I am sorry to cause confusion. The format is right. :sweat_smile: 