### PR TITLE
feat(ToolbarMenu): sticky formatting toolbar position - I314

### DIFF
--- a/examples/src/index.css
+++ b/examples/src/index.css
@@ -80,3 +80,8 @@ blockquote span {
 	height: 100%;
 	outline: none;
 }
+
+/*override semantic-ui grid padding */
+.demo-rich-text-editor {
+	padding: 0px !important; 
+}

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -131,7 +131,7 @@ function Demo() {
             />
           </Grid.Column>
 
-          <Grid.Column>
+          <Grid.Column className="demo-rich-text-editor">
             <RichTextEditor
               readOnly={false}
               value={slateValue}

--- a/src/RichTextEditor/FormattingToolbar/ToolbarMenu.js
+++ b/src/RichTextEditor/FormattingToolbar/ToolbarMenu.js
@@ -2,7 +2,12 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Menu = styled.div`
-  position: relative;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  background-color: #FFF;
+  padding: 15px;
+  z-index: 10;
   display: flex;
   align-content: space-evenly;
   justify-content: center;

--- a/src/RichTextEditor/FormattingToolbar/index.js
+++ b/src/RichTextEditor/FormattingToolbar/index.js
@@ -52,7 +52,7 @@ const FormattingToolbar = ({ canBeFormatted, showLinkModal, setShowLinkModal }) 
 
 
   return (
-    <ToolbarMenu>
+    <ToolbarMenu className="ap-rich-text-editor-toolbar">
       <StyleDropdown canBeFormatted={canBeFormatted}/>
       <Separator />
       <FormatButton {...mark} {...bold} canBeFormatted={canBeFormatted} />

--- a/src/RichTextEditor/index.js
+++ b/src/RichTextEditor/index.js
@@ -144,6 +144,7 @@ const RichTextEditor = (props) => {
         setShowLinkModal={setShowLinkModal}
         /> }
       <Editable
+        className="ap-rich-text-editor"
         readOnly={props.readOnly}
         renderElement={renderElement}
         renderLeaf={renderLeaf}

--- a/src/RichTextEditor/tests/__snapshots__/index.test.js.snap
+++ b/src/RichTextEditor/tests/__snapshots__/index.test.js.snap
@@ -623,6 +623,7 @@ This is an html block.
   />
   <Editable
     autoFocus={true}
+    className="ap-rich-text-editor"
     onCopy={[Function]}
     onCut={[Function]}
     onDOMBeforeInput={[Function]}

--- a/src/RichTextEditor/tests/index.test.js
+++ b/src/RichTextEditor/tests/index.test.js
@@ -77,6 +77,7 @@ describe('<RichTextEditor />', () => {
 
       const component = shallow(
         <RichTextEditor
+            className="ap-rich-text-editor"
             readOnly={false}
             value={slate.document.children}
             onChange={mockOnChange}

--- a/src/styles.css
+++ b/src/styles.css
@@ -37,3 +37,7 @@
 a {
     cursor: pointer;
 }
+
+.ap-rich-text-editor {
+    padding: 20px;
+}


### PR DESCRIPTION
Signed-off-by: Shrey Sachdeva <shreysachdeva.2000@gmail.com>

# Issue #314 
Make `ToolbarMenu` sticky

### Changes
- `ToolbarMenu` is now sticky and attaches to the top of the editor on scroll

### Flags
- N/A