### PR TITLE
fix(styles): fix markdown editor width - I334

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -17,7 +17,7 @@
     height: 100%;
     width: 100%;
     border: 0;
-    max-width: 45vw;
+    max-width: 100%;
 }
 
 .ap-markdown-editor .error {

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,7 +17,7 @@
     height: 100%;
     width: 100%;
     border: 0;
-    max-width: 100%;
+    resize: none;
 }
 
 .ap-markdown-editor .error {

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,6 +17,7 @@
     height: 100%;
     width: 100%;
     border: 0;
+    max-width: 45vw;
 }
 
 .ap-markdown-editor .error {


### PR DESCRIPTION
Signed-off-by: Shrey Sachdeva <shreysachdeva.2000@gmail.com>

# Issue #334 
Fix `Markdown Editor` width so it doesn't overlap with `Rich Text Editor` on resizing.

### Changes
- Set a `max-width` on `Markdown Editor`

### Flags
- N/A