### PR TITLE
fix(HyperlinkModal.js): prevent insertion of links if URL is empty

### DIFF
--- a/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
+++ b/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
@@ -96,7 +96,7 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
     // If the form is just opened, focus the Url input field
     if (props.showLinkModal) {
       setOriginalSelection(editor.selection);
-      setApplyStatus(refHyperlinkTextInput.current.props.defaultValue);
+      setApplyStatus(!!refHyperlinkTextInput.current.props.defaultValue);
       refHyperlinkTextInput.current.focus();
     }
   }, [editor, props.showLinkModal]);
@@ -118,7 +118,7 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
 
   const handleUrlInput = (event) => {
     Transforms.select(editor, originalSelection);
-    event.target.value ? setApplyStatus(true) : setApplyStatus(false);
+    setApplyStatus(!!event.target.value);
   }
 
   return (

--- a/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
+++ b/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
@@ -8,7 +8,7 @@ import {
 } from 'slate';
 import styled from 'styled-components';
 import {
-  Button, Form, Input,
+  Button, Form, Input, Label,
 } from 'semantic-ui-react';
 
 import { insertLink, isSelectionLink, unwrapLink } from '../plugins/withLinks';
@@ -61,6 +61,7 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
   const refHyperlinkTextInput = useRef();
   const editor = useEditor();
   const [originalSelection, setOriginalSelection] = useState(null);
+  const [blankUrlError, throwBlankUrlError] = useState(false);
 
   const handleClick = useCallback((e) => {
     if (ref.current && !ref.current.contains(e.target)) {
@@ -108,10 +109,15 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
 
   const applyLink = (event) => {
     Transforms.select(editor, originalSelection);
-    insertLink(editor, event.target.url.value, event.target.text.value);
-    Transforms.collapse(editor, { edge: 'end' });
-    ReactEditor.focus(editor);
-    props.setShowLinkModal(false);
+    if(event.target.url.value) {
+      insertLink(editor, event.target.url.value, event.target.text.value);
+      Transforms.collapse(editor, { edge: 'end' });
+      ReactEditor.focus(editor);
+      props.setShowLinkModal(false);
+    }
+    else {
+      throwBlankUrlError(true);
+    }
   };
 
   return (
@@ -133,6 +139,11 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
                 defaultValue={defaultLinkValue}
                 name="url"
               />
+              {blankUrlError && (
+                <Label basic color="red" size="mini" pointing>
+                  Please enter the URL
+                </Label>
+              )}
           </Form.Field>
           <Form.Field>
               <Button secondary floated="right"


### PR DESCRIPTION
Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>

### Changes
- Add a state `blankUrlError` to keep track of the URL if valid data is entered in the modal.
- If the URL is blank, error is displayed something like this:
![Screenshot from 2020-04-14 12-43-35](https://user-images.githubusercontent.com/35191225/79196385-9c6a1180-7e4d-11ea-9685-3b288c592113.png)
- For further demonstration, here is a screencast:
![accord](https://user-images.githubusercontent.com/35191225/79196959-96c0fb80-7e4e-11ea-8f62-5443bafad16c.gif)


### Flags
- Instead of checking if the URL is empty, we should add RegEx to validate if it is a URL or not.