### PR TITLE
feat(RichTextEditor): break from empty block on enter - I321

### DIFF
--- a/src/RichTextEditor/components/index.js
+++ b/src/RichTextEditor/components/index.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImageElement from '../plugins/withImages';
-import { Code, Html, ListItem, OLList, Quote, ULList } from './Block';
-import { Heading, Inline, Link, Paragraph } from './Node';
+import {
+  Code, Html, ListItem, OLList, Quote, ULList
+} from './Block';
+import {
+  Heading, Inline, Link, Paragraph
+} from './Node';
 import { HorizontalRule, Linebreak, Softbreak } from './Span';
 import {
   PARAGRAPH, LINK, IMAGE, H1, H2, H3, H4, H5, H6, HR,
@@ -10,37 +14,40 @@ import {
   HTML_INLINE, SOFTBREAK, LINEBREAK,
 } from '../utilities/schema';
 
+/* eslint react/display-name: 0 */
 const Element = (props) => {
-  const { attributes, children, element, customElements } = props;
+  const {
+    attributes, children, element, customElements
+  } = props;
   const { type, data } = element;
   const baseElementRenderer = {
-    [PARAGRAPH]: () => (<Paragraph {...attributes} children={children} />),
+    [PARAGRAPH]: () => (<Paragraph {...attributes}>{children}</Paragraph>),
     [H1]: () => (<Heading as="h1" {...attributes}>{children}</Heading>),
     [H2]: () => (<Heading as="h2" {...attributes}>{children}</Heading>),
     [H3]: () => (<Heading as="h3" {...attributes}>{children}</Heading>),
     [H4]: () => (<Heading as="h4" {...attributes}>{children}</Heading>),
     [H5]: () => (<Heading as="h5" {...attributes}>{children}</Heading>),
     [H6]: () => (<Heading as="h6" {...attributes}>{children}</Heading>),
-    [SOFTBREAK]: () => (<Softbreak {...attributes} children={children} />),
+    [SOFTBREAK]: () => (<Softbreak {...attributes}>{children}</Softbreak>),
     [LINEBREAK]: () => (<Linebreak {...attributes} />),
-    [LINK]: () => (<Link {...attributes} href={data.href} children={children} />),
-    [HTML_BLOCK]: () => (<Html {...attributes} children={children} />),
-    [CODE_BLOCK]: () => (<Code {...attributes} children={children} />),
-    [BLOCK_QUOTE]: () => (<Quote {...attributes} children={children} />),
-    [OL_LIST]: () => (<OLList {...attributes} children={children} />),
-    [UL_LIST]: () => (<ULList {...attributes} children={children} />),
-    [LIST_ITEM]: () => (<ListItem {...attributes} children={children} />),
+    [LINK]: () => (<Link {...attributes} href={data.href}>{children}</Link>),
+    [HTML_BLOCK]: () => (<Html {...attributes}>{children}</Html>),
+    [CODE_BLOCK]: () => (<Code {...attributes}>{children}</Code>),
+    [BLOCK_QUOTE]: () => (<Quote {...attributes}>{children}</Quote>),
+    [OL_LIST]: () => (<OLList {...attributes}>{children}</OLList>),
+    [UL_LIST]: () => (<ULList {...attributes}>{children}</ULList>),
+    [LIST_ITEM]: () => (<ListItem {...attributes}>{children}</ListItem>),
     [IMAGE]: () => (<ImageElement {...props} />),
     [HR]: () => (<HorizontalRule {...attributes}>{children}</HorizontalRule>),
-    [HTML_INLINE]: () => (<Inline {...attributes} content={data.content} children={children} />),
+    [HTML_INLINE]: () => (<Inline {...attributes} content={data.content}>{children}</Inline>),
     default: () => {
       console.log(`Didn't know how to render ${JSON.stringify(element, null, 2)}`);
       return <p {...attributes}>{children}</p>;
     }
   };
   const elementRenderer = customElements
-    ? {...baseElementRenderer, ...customElements(attributes, children, element) }
-    : baseElementRenderer ;
+    ? { ...baseElementRenderer, ...customElements(attributes, children, element) }
+    : baseElementRenderer;
   return (elementRenderer[type] || elementRenderer.default)();
 };
 

--- a/src/RichTextEditor/utilities/hotkeys.js
+++ b/src/RichTextEditor/utilities/hotkeys.js
@@ -1,33 +1,37 @@
-import * as SCHEMA from './schema';
+import {
+  PARAGRAPH, LINK, IMAGE, H1, H2, H3, H4, H5, H6, HR,
+  CODE_BLOCK, HTML_BLOCK, BLOCK_QUOTE, UL_LIST, OL_LIST, LIST_ITEM,
+  HTML_INLINE, SOFTBREAK, LINEBREAK, MARK_BOLD, MARK_ITALIC, MARK_CODE
+} from './schema';
 
 const HOTKEYS = {
   'mod+b': {
     type: 'mark',
-    code: SCHEMA.MARK_BOLD,
+    code: MARK_BOLD,
   },
   'mod+i': {
     type: 'mark',
-    code: SCHEMA.MARK_ITALIC,
+    code: MARK_ITALIC,
   },
   'mod+shift+9': {
     type: 'mark',
-    code: SCHEMA.MARK_CODE,
+    code: MARK_CODE,
   },
   'mod+shift+7': {
     type: 'block',
-    code: SCHEMA.OL_LIST,
+    code: OL_LIST,
   },
   'mod+shift+8': {
     type: 'block',
-    code: SCHEMA.UL_LIST,
+    code: UL_LIST,
   },
   'mod+shift+.': {
     type: 'block',
-    code: SCHEMA.BLOCK_QUOTE,
+    code: BLOCK_QUOTE,
   },
   'mod+shift+g': {
     type: 'image',
-    code: SCHEMA.IMAGE,
+    code: IMAGE,
   },
   'mod+z': {
     type: 'special',
@@ -39,6 +43,15 @@ const HOTKEYS = {
   }
 };
 
+export const ENTER_BREAKS = {
+  [BLOCK_QUOTE]: true,
+  [OL_LIST]: true,
+  [UL_LIST]: true,
+};
+
 export const formattingHotKeys = ['mod+b', 'mod+i', 'mod+shift+7', 'mod+shift+8', 'mod+shift+9', 'mod+shift+.', 'mod+shift+g'];
+
+export const ENTER = 'enter';
+export const ENTER_SHIFT = 'shift+enter';
 
 export default HOTKEYS;


### PR DESCRIPTION
# Closes #321 
Pressing enter twice should escape a block(quote)

### Changes
- Break from any current block type (UL, OL, Blockquote)
  - If the current selection is an empty text node
- Correct the passing of `children` into elements

### Flags
- Breaking from a list results in similar bugs to #323 and #335

### Related Issues
- Issue #323
- Issue #335

