### PR TITLE
feat(HyperlinkModal): added tooltips to action icons

### DIFF
--- a/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
+++ b/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
@@ -241,8 +241,7 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
               <Popup
                 trigger={
                   <LinkIconHolder
-                    disabled={!isSelectionLink(editor)}
-                    onClick={removeLink}
+                    onClick={isSelectionLink(editor) ? removeLink : null}
                     aria-label="Remove hyperlink"
                   >
                     <DeleteIcon />

--- a/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
+++ b/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
@@ -8,7 +8,7 @@ import {
 } from 'slate';
 import styled from 'styled-components';
 import {
-  Button, Form, Input,
+  Button, Form, Input, Popup
 } from 'semantic-ui-react';
 
 import { insertLink, isSelectionLink, unwrapLink } from '../plugins/withLinks';
@@ -99,6 +99,11 @@ const InlineFormButton = styled.button`
     background-color: #265FC4;
   }
 `;
+
+const popupStyles = {
+  padding: '0.2em 0.5em 0.2em 0.5em',
+  zIndex: '9999'
+}
 
 // eslint-disable-next-line react/display-name
 const HyperlinkMenu = React.forwardRef(
@@ -219,25 +224,49 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
               </InlineFormButton>
           </InlineFormField>
           <InlineFormField>
-              <LinkIconHolder
-                onClick={copyLink}
-                aria-label="Copy hyperlink text"
-              >
-                <CopyIcon />
-              </LinkIconHolder>
-              <LinkIconHolder
-                disabled={!isSelectionLink(editor)}
-                onClick={removeLink}
-                aria-label="Remove hyperlink"
-              >
-                <DeleteIcon />
-              </LinkIconHolder>
-              <LinkIconHolder
-                onClick={openLink}
-                aria-label="Open hyperlink"
-              >
-                <OpenIcon />
-              </LinkIconHolder>
+              <Popup
+                trigger={
+                  <LinkIconHolder
+                    onClick={copyLink}
+                    aria-label="Copy hyperlink text"
+                  >
+                    <CopyIcon />
+                  </LinkIconHolder>
+                }
+                content="Copy hyperlink text"
+                inverted
+                position='bottom left'
+                style={popupStyles}
+              />
+              <Popup
+                trigger={
+                  <LinkIconHolder
+                    disabled={!isSelectionLink(editor)}
+                    onClick={removeLink}
+                    aria-label="Remove hyperlink"
+                  >
+                    <DeleteIcon />
+                  </LinkIconHolder>
+                }
+                content="Remove hyperlink"
+                inverted
+                position='bottom left'
+                style={popupStyles}
+              />
+              <Popup
+                trigger={
+                  <LinkIconHolder
+                    onClick={openLink}
+                    aria-label="Open hyperlink"
+                  >
+                    <OpenIcon />
+                  </LinkIconHolder>
+                }
+                content="Open link in a new tab"
+                inverted
+                position='bottom left'
+                style={popupStyles}
+              />
           </InlineFormField>
         </Form>
       </HyperlinkMenu>

--- a/src/RichTextEditor/components/icons/copy.js
+++ b/src/RichTextEditor/components/icons/copy.js
@@ -4,7 +4,6 @@ export default () => {
   return (
     <div>
       <svg width="18px" height="18px" viewBox="0 0 17 20" version="1.1" xmlns="http://www.w3.org/2000/svg">
-        <title>Copy link url</title>
         <g id="Old-pages" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g id="Hyperlink-UI" transform="translate(-15.000000, -162.000000)">
                 <g id="Group-6" transform="translate(0.000000, 2.000000)">

--- a/src/RichTextEditor/components/icons/delete.js
+++ b/src/RichTextEditor/components/icons/delete.js
@@ -4,7 +4,6 @@ export default () => {
   return (
     <div>
       <svg width="18px" height="18px" viewBox="0 0 19 19" version="1.1" xmlns="http://www.w3.org/2000/svg">
-        <title>Remove Link</title>
         <g id="Old-pages" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g id="Hyperlink-UI" transform="translate(-44.000000, -163.000000)" fill="#959CA3" fill-rule="nonzero">
                 <g id="Group-6" transform="translate(0.000000, 2.000000)">

--- a/src/RichTextEditor/components/icons/open.js
+++ b/src/RichTextEditor/components/icons/open.js
@@ -4,7 +4,6 @@ export default () => {
   return (
     <div>
       <svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg">
-        <title>Open link in a new tab</title>
         <g id="Old-pages" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g id="Hyperlink-UI" transform="translate(-75.000000, -163.000000)" fill="#959CA3" fill-rule="nonzero">
                 <g id="Group-6" transform="translate(0.000000, 2.000000)">


### PR DESCRIPTION
Signed-off-by: elit-altum <manan.sharma311@gmail.com>

<OVERALL SUMMARY OF PULL REQUEST>

### Changes
- Added tooltips to the HyperlinkModal action icons using Semantic-UI Popup

Screenshot:
![New-Tooltips](https://user-images.githubusercontent.com/41413622/79478353-ee1ac380-8028-11ea-82b3-e90529208d37.gif)


### Flags
- Please review the tooltip messages. The current ones are:
   - Copy Icon: Copy hyperlink text
   - Remove Icon: Remove hyperlink
   - Open Icon: Open link in a new tab

### Related Issues
- Pull Request #351 