### PR TITLE
chore(dep) Upgrade to latest version of markdown transform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,12 @@
       }
     },
     "@accordproject/markdown-cicero": {
-      "version": "0.10.5-20200410190852",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.10.5-20200410190852.tgz",
-      "integrity": "sha512-5eZbVNYRjvSv1oUmkxGJv0/gD3PtwkV9cK+3R7Jj0SikJAXK/eO3uTMTQ7IhhnxUILMzzQxc32Bqz0d60PaRRw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.1.tgz",
+      "integrity": "sha512-H+HXa8BbUw/CjFy18NG6YI0LkxwEfOVWSa6y9at3gCBKNnxlvJbFqTyqckdXSGltbTCtXyHWVXZZeFyaAgIfcg==",
       "requires": {
-        "@accordproject/concerto-core": "^0.82.6",
-        "@accordproject/markdown-common": "0.10.5-20200410190852",
+        "@accordproject/concerto-core": "^0.82.7",
+        "@accordproject/markdown-common": "0.11.1",
         "commonmark": "^0.29.0",
         "jsome": "2.5.0",
         "sax": "^1.2.4",
@@ -37,11 +37,11 @@
       }
     },
     "@accordproject/markdown-common": {
-      "version": "0.10.5-20200410190852",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.5-20200410190852.tgz",
-      "integrity": "sha512-lsyqW908nDnZ8LdGartTHJhECYgElzGoMtmuqqr+pZ30TfFb94YEynJPRoSYF2FztwRYdtSqkpQFSM2MhD/+uQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.1.tgz",
+      "integrity": "sha512-DmpnMBoNP3vfi0LkKm6j9Te8MgIuNcZzk2GZS859nmhSzsXr/7tYpfPfpENYcjBBUh4WQPwLhLit3w9AwIE48Q==",
       "requires": {
-        "@accordproject/concerto-core": "^0.82.6",
+        "@accordproject/concerto-core": "^0.82.7",
         "commonmark": "^0.29.0",
         "jsome": "2.5.0",
         "sax": "^1.2.4",
@@ -50,22 +50,22 @@
       }
     },
     "@accordproject/markdown-html": {
-      "version": "0.10.5-20200410190852",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.10.5-20200410190852.tgz",
-      "integrity": "sha512-UJG6PCsXwsMNWVGWB3Et4sFzeK/Y2Js3n6XWAl1L8v9mh6m2gfdaQaRVEiofgxSAUIkICKKHJuY5r04jSDj5Hw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.1.tgz",
+      "integrity": "sha512-wmy8v6F0R9S+RX3QcrA3zO6e80RBIQwM+lYU7IARwL/mqwz1ywmvIdLmcMr/0h41d09pYTqZmBs77+29BOTuFQ==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.10.5-20200410190852",
-        "@accordproject/markdown-common": "0.10.5-20200410190852",
+        "@accordproject/markdown-cicero": "0.11.1",
+        "@accordproject/markdown-common": "0.11.1",
         "jsdom": "^15.2.1",
         "type-of": "^2.0.1"
       }
     },
     "@accordproject/markdown-slate": {
-      "version": "0.10.5-20200410190852",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.10.5-20200410190852.tgz",
-      "integrity": "sha512-BWMCI+Jt9GBRzdTfuMC1+o8P3w9g6LsreR6DrvrKSyQcpthDr4N9wdMfhDK/QuSIaUVwDMlfneSsaVU22gF6TA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.11.1.tgz",
+      "integrity": "sha512-r/ibP/vNTTxHji63hoHwqixUT5tAwoBG1MIYzzV5VFPB3R4GdoShimp2oaUylmHGRjAhZWlsxT4psUj7Q0V0vg==",
       "requires": {
-        "@accordproject/markdown-cicero": "0.10.5-20200410190852"
+        "@accordproject/markdown-cicero": "0.11.1"
       }
     },
     "@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -104,8 +104,8 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@accordproject/markdown-html": "0.10.5-20200410190852",
-    "@accordproject/markdown-slate": "0.10.5-20200410190852",
+    "@accordproject/markdown-html": "^0.11.1",
+    "@accordproject/markdown-slate": "^0.11.1",
     "@babel/runtime": "^7.8.7",
     "@material-ui/core": "^4.9.5",
     "@material-ui/icons": "^4.9.1",

--- a/src/RichTextEditor/index.js
+++ b/src/RichTextEditor/index.js
@@ -100,7 +100,7 @@ const RichTextEditor = (props) => {
     // https://github.com/ianstormtaylor/slate/issues/3577
     // We need to take a functional approach
     // https://github.com/accordproject/markdown-transform/issues/203
-    const SLATE_CHILDREN = JSON.parse(JSON.stringify(Node.fragment(editor, editor.selection)));
+    const SLATE_CHILDREN = Node.fragment(editor, editor.selection);
     const SLATE_DOM = {
       object: 'value',
       document: {

--- a/src/RichTextEditor/tests/__snapshots__/index.test.js.snap
+++ b/src/RichTextEditor/tests/__snapshots__/index.test.js.snap
@@ -142,6 +142,7 @@ exports[`<RichTextEditor /> on initialization renders page correctly 1`] = `
           Object {
             "children": Array [
               Object {
+                "object": "text",
                 "text": "",
               },
             ],
@@ -167,6 +168,7 @@ exports[`<RichTextEditor /> on initialization renders page correctly 1`] = `
           Object {
             "children": Array [
               Object {
+                "object": "text",
                 "text": "",
               },
             ],
@@ -186,6 +188,7 @@ exports[`<RichTextEditor /> on initialization renders page correctly 1`] = `
       Object {
         "children": Array [
           Object {
+            "object": "text",
             "text": "",
           },
         ],
@@ -207,6 +210,10 @@ exports[`<RichTextEditor /> on initialization renders page correctly 1`] = `
       },
       Object {
         "children": Array [
+          Object {
+            "object": "text",
+            "text": "",
+          },
           Object {
             "children": Array [
               Object {
@@ -502,6 +509,7 @@ This is an html block.
           Object {
             "children": Array [
               Object {
+                "object": "text",
                 "text": "",
               },
             ],
@@ -518,6 +526,7 @@ This is an html block.
           Object {
             "children": Array [
               Object {
+                "object": "text",
                 "text": "",
               },
             ],


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- Upgrade to latest markdown transform
- Slate DOM has bold/italics annotations on parent node in some cases (instead of text node)
- Tested on demo for non-clauses
- Includes cloning Slate DOM when transforming to markdown to avoid immutability issues
- Includes fixes for https://github.com/accordproject/cicero-ui/issues/378 by @irmerk 
- Removes now unnecessary cloning in `handleCopyOrCut`

### Flags
- Done minimal local testing
