### PR TITLE
refactor(*): remove unused lockText prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ function storeLocal(slateValue) {
   localStorage.setItem('markdown-editor', markdown);
 }
 
-ReactDOM.render(<SlateAsInputEditor plugins={plugins} lockText={false} onChange={storeLocal}/>
+ReactDOM.render(<SlateAsInputEditor plugins={plugins} onChange={storeLocal}/>
 , document.getElementById('root'));
 ```
 

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -83,8 +83,8 @@ const propsObj = {
 
 
 /**
- * Simple demo component that tracks whether to lockText
- * and whether to use markdown mode.
+ * Simple demo component that shows markdown and rich text
+ * side by side
  */
 function Demo() {
   /**
@@ -134,7 +134,6 @@ function Demo() {
           <Grid.Column>
             <RichTextEditor
               readOnly={false}
-              lockText={true}
               value={slateValue}
               onChange={onSlateValueChange}
               editorProps={propsObj}

--- a/src/RichTextEditor/index.js
+++ b/src/RichTextEditor/index.js
@@ -139,7 +139,6 @@ const RichTextEditor = (props) => {
     <Slate editor={editor} value={props.value} onChange={onChange}>
       { !props.readOnly
         && <FormatBar
-        lockText={props.lockText}
         canBeFormatted={props.canBeFormatted}
         showLinkModal={showLinkModal}
         setShowLinkModal={setShowLinkModal}
@@ -172,8 +171,6 @@ RichTextEditor.propTypes = {
   onChange: PropTypes.func.isRequired,
   /* Boolean to make editor read-only (uneditable) or not (editable) */
   readOnly: PropTypes.bool,
-  /* Boolean to lock non variable text */
-  lockText: PropTypes.bool,
   /* Higher order function to augment the editor methods */
   augmentEditor: PropTypes.func,
   /* Array of plugins passed in for the editor */

--- a/src/RichTextEditor/tests/__snapshots__/index.test.js.snap
+++ b/src/RichTextEditor/tests/__snapshots__/index.test.js.snap
@@ -618,7 +618,6 @@ This is an html block.
 >
   <FormattingToolbar
     canBeFormatted={[Function]}
-    lockText={true}
     setShowLinkModal={[Function]}
     showLinkModal={false}
   />

--- a/src/RichTextEditor/tests/index.test.js
+++ b/src/RichTextEditor/tests/index.test.js
@@ -78,7 +78,6 @@ describe('<RichTextEditor />', () => {
       const component = shallow(
         <RichTextEditor
             readOnly={false}
-            lockText={true}
             value={slate.document.children}
             onChange={mockOnChange}
         />


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

- `lockText` should only be used at the ContractEditor level in cicero-ui since it deals with the ability to edit clauses/variables
- it is no longer used by the markdown-editor specifically, so I have removed it