### PR TITLE
fix(utilities): handle block toggles - I323

### DIFF
--- a/src/RichTextEditor/utilities/toolbarHelpers.js
+++ b/src/RichTextEditor/utilities/toolbarHelpers.js
@@ -28,7 +28,9 @@ export const toggleBlock = (editor, format) => {
   Transforms.unwrapNodes(editor, { match: n => LIST_TYPES.includes(n.type), split: true });
 
   if (!isActive) {
-    const formattedBlock = { type: format, children: [], data: { tight: true } };
+    const formattedBlock = {
+      type: format, children: [], data: (isQuote(format) ? {} : { tight: true })
+    };
     Transforms.wrapNodes(editor, formattedBlock);
 
     if (isList(format)) {


### PR DESCRIPTION
# Closes #323
Handle roundtrip action of toggling block types

### Changes
- Unwraps all block types
- If the selection began as not a block, wrap in the format
  - If the format is a list, wrap each child node in a `list_item`

### Flags
- N/A