### PR TITLE
feat(RichTextEditor): add ID to headings

### DIFF
--- a/src/RichTextEditor/components/index.js
+++ b/src/RichTextEditor/components/index.js
@@ -20,14 +20,27 @@ const Element = (props) => {
     attributes, children, element, customElements
   } = props;
   const { type, data } = element;
+  const headings = [H1, H2, H3, H4, H5, H6];
+  let headingId;
+  if (headings.includes(type)) {
+    // https://github.com/thlorenz/anchor-markdown-header/blob/87e4cca4618271e363f4af9697df0f73f23b3d3f/anchor-markdown-header.js#L20
+    headingId = element.children[0].text.replace(/ /g,'-')
+    // escape codes
+    .replace(/%([abcdef]|\d){2,2}/ig, '')
+    // single chars that are removed
+    .replace(/[\/?!:\[\]`.,()*"';{}+=<>~\$|#@&–—]/g,'')
+    // CJK punctuations that are removed
+    .replace(/[。？！，、；：“”【】（）〔〕［］﹃﹄“ ”‘’﹁﹂—…－～《》〈〉「」]/g, '')
+    ;
+  }
   const baseElementRenderer = {
     [PARAGRAPH]: () => (<Paragraph {...attributes}>{children}</Paragraph>),
-    [H1]: () => (<Heading as="h1" {...attributes}>{children}</Heading>),
-    [H2]: () => (<Heading as="h2" {...attributes}>{children}</Heading>),
-    [H3]: () => (<Heading as="h3" {...attributes}>{children}</Heading>),
-    [H4]: () => (<Heading as="h4" {...attributes}>{children}</Heading>),
-    [H5]: () => (<Heading as="h5" {...attributes}>{children}</Heading>),
-    [H6]: () => (<Heading as="h6" {...attributes}>{children}</Heading>),
+    [H1]: () => (<Heading id={headingId} as="h1" {...attributes}>{children}</Heading>),
+    [H2]: () => (<Heading id={headingId} as="h2" {...attributes}>{children}</Heading>),
+    [H3]: () => (<Heading id={headingId} as="h3" {...attributes}>{children}</Heading>),
+    [H4]: () => (<Heading id={headingId} as="h4" {...attributes}>{children}</Heading>),
+    [H5]: () => (<Heading id={headingId} as="h5" {...attributes}>{children}</Heading>),
+    [H6]: () => (<Heading id={headingId} as="h6" {...attributes}>{children}</Heading>),
     [SOFTBREAK]: () => (<Softbreak {...attributes}>{children}</Softbreak>),
     [LINEBREAK]: () => (<Linebreak {...attributes} />),
     [LINK]: () => (<Link {...attributes} href={data.href}>{children}</Link>),

--- a/src/RichTextEditor/components/index.js
+++ b/src/RichTextEditor/components/index.js
@@ -11,28 +11,16 @@ import { HorizontalRule, Linebreak, Softbreak } from './Span';
 import {
   PARAGRAPH, LINK, IMAGE, H1, H2, H3, H4, H5, H6, HR,
   CODE_BLOCK, HTML_BLOCK, BLOCK_QUOTE, UL_LIST, OL_LIST, LIST_ITEM,
-  HTML_INLINE, SOFTBREAK, LINEBREAK,
+  HTML_INLINE, SOFTBREAK, LINEBREAK, HEADINGS
 } from '../utilities/schema';
+import generateId from '../utilities/generateId';
 
-/* eslint react/display-name: 0 */
 const Element = (props) => {
   const {
     attributes, children, element, customElements
   } = props;
   const { type, data } = element;
-  const headings = [H1, H2, H3, H4, H5, H6];
-  let headingId;
-  if (headings.includes(type)) {
-    // https://github.com/thlorenz/anchor-markdown-header/blob/87e4cca4618271e363f4af9697df0f73f23b3d3f/anchor-markdown-header.js#L20
-    headingId = element.children[0].text.replace(/ /g,'-')
-    // escape codes
-    .replace(/%([abcdef]|\d){2,2}/ig, '')
-    // single chars that are removed
-    .replace(/[\/?!:\[\]`.,()*"';{}+=<>~\$|#@&–—]/g,'')
-    // CJK punctuations that are removed
-    .replace(/[。？！，、；：“”【】（）〔〕［］﹃﹄“ ”‘’﹁﹂—…－～《》〈〉「」]/g, '')
-    ;
-  }
+  const headingId = HEADINGS.includes(type) ? generateId(element): null;
   const baseElementRenderer = {
     [PARAGRAPH]: () => (<Paragraph {...attributes}>{children}</Paragraph>),
     [H1]: () => (<Heading id={headingId} as="h1" {...attributes}>{children}</Heading>),

--- a/src/RichTextEditor/utilities/generateId.js
+++ b/src/RichTextEditor/utilities/generateId.js
@@ -1,0 +1,10 @@
+// https://github.com/thlorenz/anchor-markdown-header/blob/87e4cca4618271e363f4af9697df0f73f23b3d3f/anchor-markdown-header.js#L20
+const generateId = element => element.children[0].text.replace(/ /g, '-')
+  // escape codes
+  .replace(/%([abcdef]|\d){2,2}/ig, '')
+  // single chars that are removed
+  .replace(/[\/?!:\[\]`.,()*"';{}+=<>~\$|#@&–—]/g, '')
+  // CJK punctuations that are removed
+  .replace(/[。？！，、；：“”【】（）〔〕［］﹃﹄“ ”‘’﹁﹂—…－～《》〈〉「」]/g, '');
+
+export default generateId;


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

- Adds `id` attributes to headings. The function for transforming the heading text into a viable anchor was taken from here: https://github.com/thlorenz/anchor-markdown-header/blob/87e4cca4618271e363f4af9697df0f73f23b3d3f/anchor-markdown-header.js#L20