### PR TITLE
fix(FormattingToolbar): fixes change of viewport for link modal - I376

### DIFF
--- a/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
+++ b/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
@@ -19,40 +19,38 @@ import OpenIcon from '../components/icons/open';
 import DeleteIcon from '../components/icons/delete';
 
 const HyperlinkWrapper = styled.div`
-    position: absolute;
-    z-index: 3000;
-    top: -10000px;
-    left: -10000px;
-    margin-top: -6px;
-    opacity: 0;
-    background-color: #FFFFFF;
-    border: 1px solid #d4d4d5;
-    border-radius: .3rem;
-    transition: opacity 0.75s;
+  position: absolute;
+  z-index: 3000;
+  margin-top: -6px;
+  opacity: 0;
+  background-color: #FFFFFF;
+  border: 1px solid #d4d4d5;
+  border-radius: .3rem;
+  transition: opacity 0.75s;
 
-    min-width: min-content;
-    line-height: 1.4285em;
-    max-width: 250px;
-    padding: .833em 1em;
-    font-weight: 400;
-    font-style: normal;
-    color: rgba(0,0,0,.87);
-    box-shadow: 0 2px 4px 0 rgba(34,36,38,.12), 0 2px 10px 0 rgba(34,36,38,.15);
-    & > * {
-        display: inline-block;
-    }
+  min-width: min-content;
+  line-height: 1.4285em;
+  max-width: 250px;
+  padding: .833em 1em;
+  font-weight: 400;
+  font-style: normal;
+  color: rgba(0,0,0,.87);
+  box-shadow: 0 2px 4px 0 rgba(34,36,38,.12), 0 2px 10px 0 rgba(34,36,38,.15);
+  & > * {
+      display: inline-block;
+  }
 `;
 const HyperlinkCaret = styled.div`
-    position: absolute;
-    z-index: 4000;
-    left: calc(50% - 5px);
-    top: -10px;
-    height: 0;
-    width: 0;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-bottom: 10px solid #d4d4d5;
-    transition: opacity 0.75s;
+  position: absolute;
+  z-index: 4000;
+  left: calc(50% - 5px);
+  top: -10px;
+  height: 0;
+  width: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 10px solid #d4d4d5;
+  transition: opacity 0.75s;
 `;
 
 const LinkIconHolder = styled.div`

--- a/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
+++ b/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
@@ -21,6 +21,8 @@ import DeleteIcon from '../components/icons/delete';
 const HyperlinkWrapper = styled.div`
   position: absolute;
   z-index: 3000;
+  top: -10000px;
+  left: -10000px;
   margin-top: -6px;
   opacity: 0;
   background-color: #FFFFFF;

--- a/src/RichTextEditor/FormattingToolbar/index.js
+++ b/src/RichTextEditor/FormattingToolbar/index.js
@@ -49,7 +49,7 @@ const FormattingToolbar = ({ canBeFormatted, showLinkModal, setShowLinkModal }) 
           + rect.width / 2}px`;
 
       // adjust window scroll to bring focus to the modal
-      let scrollY = rect.top + rect.height + window.pageYOffset + CARET_TOP_OFFSET;
+      let scrollY = rect.top + rect.height + window.pageYOffset - 100;
       window.scrollTo(0, scrollY);
     }
   }, [editor, showLinkModal]);

--- a/src/RichTextEditor/FormattingToolbar/index.js
+++ b/src/RichTextEditor/FormattingToolbar/index.js
@@ -47,6 +47,10 @@ const FormattingToolbar = ({ canBeFormatted, showLinkModal, setShowLinkModal }) 
           + window.pageXOffset
           - el.offsetWidth / 2
           + rect.width / 2}px`;
+
+      // adjust window scroll to bring focus to the modal
+      let scrollY = rect.top + rect.height + window.pageYOffset + CARET_TOP_OFFSET;
+      window.scrollTo(0, scrollY);
     }
   }, [editor, showLinkModal]);
 


### PR DESCRIPTION
Signed-off-by: elit-altum <manan.sharma311@gmail.com>

# Issue #376 
<OVERALL SUMMARY OF PULL REQUEST>

### Changes
- Added the ```window.scroll()``` method to scroll to the HyperlinkModal's viewport
- Also changed the ```HyperLinkWrapper``` and ```HyperLinkCaret``` styles to tab of 2.

### Flags
- Was the indentation of the fields intentionally of 4 tab spaces? If yes, I will revert it!
