### PR TITLE
feat(demo): added labels for markdown and preview - I345

### DIFF
--- a/examples/src/index.css
+++ b/examples/src/index.css
@@ -81,7 +81,9 @@ blockquote span {
 	outline: none;
 }
 
-/*override semantic-ui grid padding */
-.demo-rich-text-editor {
-	padding: 0px !important; 
+.heading {
+	font-size: 18px;
+	text-align: center;
+	position: relative;
+	text-transform: uppercase;
 }

--- a/examples/src/index.css
+++ b/examples/src/index.css
@@ -87,3 +87,7 @@ blockquote span {
 	position: relative;
 	text-transform: uppercase;
 }
+
+.ap-rich-text-editor-toolbar {
+    box-shadow: 0 4px 2px -2px rgba(0,0,0,.2);
+} 

--- a/examples/src/index.css
+++ b/examples/src/index.css
@@ -87,7 +87,3 @@ blockquote span {
 	position: relative;
 	text-transform: uppercase;
 }
-
-.ap-rich-text-editor-toolbar {
-    box-shadow: 0 4px 2px -2px rgba(0,0,0,.2);
-} 

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -124,6 +124,7 @@ function Demo() {
       <Segment>
         <Grid columns={2}>
           <Grid.Column>
+          <h1 className="heading">Markdown</h1>
             <MarkdownTextEditor
               readOnly={true}
               markdown={markdown}
@@ -132,6 +133,7 @@ function Demo() {
           </Grid.Column>
 
           <Grid.Column className="demo-rich-text-editor">
+          <h1 className="heading">Preview</h1>
             <RichTextEditor
               readOnly={false}
               value={slateValue}
@@ -140,7 +142,7 @@ function Demo() {
             />
           </Grid.Column>
         </Grid>
-        <Divider vertical>Preview</Divider>
+        <Divider vertical/>
       </Segment>
     </div>
   );


### PR DESCRIPTION
Signed-off-by: Arteev Raina <arteevraina@gmail.com>

## Issue #345 #337 
Separate labels for `Markdown` and `Preview` have been added.

## Screenshot
![image](https://user-images.githubusercontent.com/43968121/80519743-1817a280-89a6-11ea-81fb-cab1941a94c0.png)

## Related Issues
- Issue #345 #337 
- Previous Pull Request #367 

Please Review and suggest changes @irmerk @Michael-Grover @DianaLease :)