### PR TITLE
fix(toolbarHelpers): update type of node  instead of wrapping node if updating heading style

### DIFF
--- a/src/RichTextEditor/components/index.js
+++ b/src/RichTextEditor/components/index.js
@@ -20,7 +20,7 @@ const Element = (props) => {
     attributes, children, element, customElements
   } = props;
   const { type, data } = element;
-  const headingId = HEADINGS.includes(type) ? generateId(element): null;
+  const headingId = HEADINGS.includes(type) ? generateId(element) : null;
   const baseElementRenderer = {
     [PARAGRAPH]: () => (<Paragraph {...attributes}>{children}</Paragraph>),
     [H1]: () => (<Heading id={headingId} as="h1" {...attributes}>{children}</Heading>),

--- a/src/RichTextEditor/utilities/toolbarHelpers.js
+++ b/src/RichTextEditor/utilities/toolbarHelpers.js
@@ -27,6 +27,11 @@ export const toggleBlock = (editor, format) => {
   Transforms.unwrapNodes(editor, { match: n => isListItem(n.type), split: true });
   Transforms.unwrapNodes(editor, { match: n => LIST_TYPES.includes(n.type), split: true });
 
+  if (format === 'paragraph' || format.startsWith('heading')) {
+    Transforms.setNodes(editor, { type: format });
+    return;
+  }
+
   if (!isActive) {
     const formattedBlock = {
       type: format, children: [], data: (isQuote(format) ? {} : { tight: true })


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

# Issue 
- Previously when adding a heading, we would wrap the children nodes in a heading node, resulting in a paragraph inside of a heading

### Changes
- Update type of node using `setNodes` instead of wrapping node if going from paragraph to heading or vice versa.

## FLAGS
- Please test links in headings