### PR TITLE
feat(hyperlink Modal): fix hyperlink modal accepts invalid urls

### DIFF
--- a/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
+++ b/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
@@ -161,9 +161,18 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
     props.setShowLinkModal(false);
   };
 
+  const validateUrl = (url) => {
+    const isUrlInvalid = !(url.startsWith('http://') || url.startsWith('https://'));
+    if (isUrlInvalid) {
+      url = `https://${url}`;
+    }
+    return url;
+  };
+
   const applyLink = (event) => {
+    const newUrl = validateUrl(event.target.url.value);
     Transforms.select(editor, originalSelection);
-    insertLink(editor, event.target.url.value, event.target.text.value);
+    insertLink(editor, newUrl, event.target.text.value);
     Transforms.collapse(editor, { edge: 'end' });
     ReactEditor.focus(editor);
     props.setShowLinkModal(false);

--- a/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
+++ b/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
@@ -164,7 +164,7 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
   const validateUrl = (url) => {
     const isUrlInvalid = !(url.startsWith('http://') || url.startsWith('https://'));
     if (isUrlInvalid) {
-      url = `https://${url}`;
+      return `https://${url}`;
     }
     return url;
   };


### PR DESCRIPTION
Signed-off-by: Nikhil <nikhilsharmarockstar21@gmail.com>

# Issue #365 
This PR adds the feature to insert `https://` if the URL does not start with a valid prefix

### Changes
- Added logic for prefixing the URL with `https://` if the URL does not start with `http://` or `https://`