### PR TITLE
fix(FormattingToolbar): prevent hyperlink crashing

### DIFF
--- a/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
+++ b/src/RichTextEditor/FormattingToolbar/HyperlinkModal.js
@@ -140,7 +140,7 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
     }
   }, [editor]);
 
-  const defaultLinkValue = isSelectionLink(editor)
+  const defaultLinkValue = (editor.selection && isSelectionLink(editor))
     ? Node.parent(editor, editor.selection.focus.path).data.href
     : '';
 
@@ -252,7 +252,7 @@ const HyperlinkModal = React.forwardRef(({ ...props }, ref) => {
               <Popup
                 trigger={
                   <LinkIconHolder
-                    onClick={isSelectionLink(editor) ? removeLink : null}
+                    onClick={removeLink}
                     aria-label="Remove hyperlink"
                   >
                     <DeleteIcon />


### PR DESCRIPTION
# No Issue
Put further protections in the hyperlink modal

### Changes
- The remove link button does not need to determine if something is a link, the `unwrapLink` function does nothing if the selection is not a link
- `defaultLinkValue` was sometimes failing because there was no selection