### PR TITLE
feat(RichTextEditor): allow consumer to prevent actions

### DIFF
--- a/src/RichTextEditor/index.js
+++ b/src/RichTextEditor/index.js
@@ -70,7 +70,7 @@ const RichTextEditor = (props) => {
   };
 
   const onKeyDown = useCallback((event) => {
-    if (canKeyDown && !canKeyDown(editor, event)) {
+    if (!canKeyDown(editor, event)) {
       event.preventDefault();
       return;
     }
@@ -99,7 +99,7 @@ const RichTextEditor = (props) => {
 
   const handleCopyOrCut = useCallback((event, cut) => {
     event.preventDefault();
-    if (canCopy && !canCopy(editor)) return;
+    if (!canCopy(editor)) return;
     const slateTransformer = new SlateTransformer();
     const htmlTransformer = new HtmlTransformer();
     const ciceroMarkTransformer = new CiceroMarkTransformer();
@@ -187,6 +187,8 @@ RichTextEditor.propTypes = {
 RichTextEditor.defaultProps = {
   isEditable: () => true,
   canBeFormatted: () => true,
+  canCopy: () => true,
+  canKeyDown: () => true,
 };
 
 


### PR DESCRIPTION
# No Issue
Allow consumer of `markdown-editor` to prevent certain actions

### Changes
- Sets groundwork for preventing `onKeyDown`
- Sets groundwork for preventing `onCopy` and `onCut`

### Flags
- This will be done in conjunction with work in `cicero-ui` where the Contract Editor can prevent <kbd>BACKSPACE</kbd> when cursor is on the last node but the previous node is a smart clause template.
- This will also be done in conjunction with work in `cicero-ui` where the Contract Editor can prevent <kbd>CMD</kbd>+<kbd>C</kbd> and <kbd>CMD</kbd>+<kbd>X</kbd> when the selection begins or ends inside a smart clause template.

### Related Issues
- N/A